### PR TITLE
feat(Agent): Agent 노드에 모델 상세 설정 통합 및 로직 개선

### DIFF
--- a/ui/src/components/workspace/AIConnectionForm.tsx
+++ b/ui/src/components/workspace/AIConnectionForm.tsx
@@ -7,8 +7,6 @@ interface AIConnectionFormProps {
     provider: string;
     model: string;
     apiKey: string;
-    temperature: number;
-    maxTokens: number;
     status: 'active' | 'draft' | 'archived';
   };
   setAiConnectionForm: (form: any) => void;
@@ -126,42 +124,6 @@ const AIConnectionForm: React.FC<AIConnectionFormProps> = ({
 
           </div>
         </div>
-        {activeMenu === 'ai-language' && (
-          <div>
-            <h2 className="text-lg font-medium text-gray-800 mb-4">Advanced Settings</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Temperature
-                </label>
-                <input
-                  name="temperature"
-                  value={aiConnectionForm.temperature}
-                  onChange={e => setAiConnectionForm({ ...aiConnectionForm, temperature: parseFloat(e.target.value) })}
-                  type="number"
-                  min="0"
-                  max="2"
-                  step="0.01"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="0.7"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Max Tokens
-                </label>
-                <input
-                  name="maxTokens"
-                  value={aiConnectionForm.maxTokens}
-                  onChange={e => setAiConnectionForm({ ...aiConnectionForm, maxTokens: parseInt(e.target.value, 10) })}
-                  type="number"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="2048"
-                />
-              </div>
-            </div>
-          </div>
-        )}
         <div className="pt-4 flex justify-end">
           <button
             onClick={handleSaveAIConnection}

--- a/ui/src/components/workspace/AIConnectionList.tsx
+++ b/ui/src/components/workspace/AIConnectionList.tsx
@@ -7,8 +7,6 @@ interface AIConnection {
   provider: string;
   model: string;
   apiKey?: string;
-  temperature?: number;
-  maxTokens?: number;
   status: string;
   lastModified: string;
 }
@@ -80,8 +78,7 @@ const AIConnectionList: React.FC<AIConnectionListProps> = ({
                 provider: connection.provider,
                 model: connection.model,
                 apiKey: connection.apiKey || '',
-                temperature: connection.temperature ?? 0.7,
-                maxTokens: connection.maxTokens ?? 2048,
+                status: connection.status,
               });
             }}
             className="bg-white p-6 rounded-lg border border-gray-200 hover:border-blue-300 hover:shadow-md transition-all cursor-pointer group"


### PR DESCRIPTION
Agent 노드의 모델 설정을 강화하고 관련 로직을 개선하여 데이터 정합성과 사용성을 높였습니다.

주요 변경 사항:
- **모델 설정 저장 방식 변경**:
  - `AgentSettings`에서 모델 선택 시, 모델 ID가 아닌 전체 `AI Connection` 객체를 노드 데이터에 직접 저장하도록 변경하여 데이터 관리 방식을 단순화했습니다.
  - 선택된 모델의 `Provider`와 모델명이 UI에 표시되도록 개선했습니다.

- **워크플로우 실행 및 내보내기 로직 개선**:
  - `executeNode`: Agent 노드 실행 시, 백엔드로 전달하는 `model` 정보를 상세 객체 형식으로 통일했습니다.
  - `executeNode`: `topK`, `topP`, `temperature`, `maxTokens` 값을 `modelSetting` 객체로 묶어 전달하도록 추가하고, 미설정 시 기본값을 사용하도록 보완했습니다.
  - `getWorkflowAsJSONString`: 'Export Python' 시점에 Agent 노드의 모델 정보를 지정된 포맷으로 변환하여 포함하도록 수정했습니다.

- **상태 관리 리팩토링**:
  - `flowStore`의 `updateNodeData` 함수가 부분적인 데이터 업데이트를 안전하게 병합하도록 리팩토링하여, 여러 설정 변경 시 발생할 수 있는 동기화 문제를 해결했습니다.
  - `AgentSettings`의 모든 설정 핸들러가 부분 업데이트를 사용하도록 수정했습니다.

- **AI Connection 설정 UI 간소화**:
  - `AIConnectionForm` 및 `AIConnectionList`에서 불필요해진 `temperature`와 `maxTokens` 관련 "Advanced Settings" UI와 로직을 제거했습니다.