### PR TITLE
feat: Group 노드 이름 변경(ToolsMemomorySettings) Agent 노드와 연결된 Tools와 Momo…

### DIFF
--- a/ui/src/components/NodeInspector.tsx
+++ b/ui/src/components/NodeInspector.tsx
@@ -12,6 +12,7 @@ import EmbeddingSettings from './nodes/EmbeddingSettings';
 import RAGSettings from './nodes/RAGSettings';
 import MergeSettings from './nodes/MergeSettings';
 import EndNodeSettings from './nodes/EndNodeSettings';
+import ToolsMemorySettings from './nodes/ToolsMemorySettings';
 import { Node, Edge } from 'reactflow';
 import { NodeData, VariableValue } from '../types/node';
 
@@ -113,7 +114,7 @@ const NodeInspector: React.FC<NodeInspectorProps> = ({ nodeId, onClose }) => {
   const isSystemPromptNode = currentNode.type === 'systemPromptNode';
   const isAgentNode = currentNode.type === 'agentNode';
   const isStartNode = currentNode.type === 'startNode';
-  const isGroupsNode = currentNode.type === 'groupsNode';
+  const isToolsMemoryNode = currentNode.type === 'toolsMemoryNode';
   const isEmbeddingNode = currentNode.type === 'embeddingNode';
   const isRAGNode = currentNode.type === 'ragNode';
   const isEndNode = currentNode.type === 'endNode';
@@ -168,7 +169,7 @@ const NodeInspector: React.FC<NodeInspectorProps> = ({ nodeId, onClose }) => {
                 <Settings size={16} className="mr-1" /> Settings
               </button>
             );
-          } else if (!(isStartNode || isEndNode || isAgentNode || isConditionNode || isGroupsNode || isEmbeddingNode || isRAGNode || isMergeNode)) {
+          } else if (!(isStartNode || isEndNode || isAgentNode || isConditionNode || isToolsMemoryNode || isEmbeddingNode || isRAGNode || isMergeNode)) {
             return (
               <button
                 className={`flex-1 py-2 flex justify-center items-center ${
@@ -288,7 +289,7 @@ const NodeInspector: React.FC<NodeInspectorProps> = ({ nodeId, onClose }) => {
               {isStartNode && <StartSettings nodeId={nodeId} />}
               {isConditionNode && <ConditionSettings nodeId={nodeId} />}
               {isAgentNode && <AgentSettings nodeId={nodeId} />}
-              {isGroupsNode && <GroupsSettings nodeId={nodeId} />}
+              {isToolsMemoryNode && <ToolsMemorySettings nodeId={nodeId} />}
               {isEmbeddingNode && <EmbeddingSettings nodeId={nodeId} />}
               {isRAGNode && <RAGSettings nodeId={nodeId} />}
               {isMergeNode && <MergeSettings nodeId={nodeId} />}

--- a/ui/src/components/nodes/AgentSettings.tsx
+++ b/ui/src/components/nodes/AgentSettings.tsx
@@ -75,9 +75,9 @@ const AgentSettings: React.FC<AgentSettingsProps> = ({ nodeId }) => {
   }, [nodes, edges, nodeId, getNodeById]); // getNodeById는 store에서 오므로 직접적인 의존성은 아니지만, nodes/edges 변경 시 재계산 필요
 
   // Get all groups nodes and extract memory and tools groups
-  const groupsNode = nodes.find(n => n.type === 'groupsNode');
-  const memoryGroups: GroupData[] = groupsNode?.data.config?.groups?.filter((g: GroupData) => g.type === 'memory') || [];
-  const toolsGroups: GroupData[] = groupsNode?.data.config?.groups?.filter((g: GroupData) => g.type === 'tools') || [];
+  const toolsMemoryNode = nodes.find(n => n.type === 'toolsMemoryNode');
+  const memoryGroups: GroupData[] = toolsMemoryNode?.data.config?.groups?.filter((g: GroupData) => g.type === 'memory') || [];
+  const toolsGroups: GroupData[] = toolsMemoryNode?.data.config?.groups?.filter((g: GroupData) => g.type === 'tools') || [];
 
   // Get selected tools from node config
   const currentTools = node?.data.config?.tools || []; // 'selectedTools' -> 'tools'로 변경

--- a/ui/src/components/nodes/CustomNode.tsx
+++ b/ui/src/components/nodes/CustomNode.tsx
@@ -24,9 +24,9 @@ export const CustomNode = memo(({ data, isConnectable, selected, id, type }: Nod
   const isStartNode = type === 'startNode';
   const isEndNode = type === 'endNode';
   const isConditionNode = type === 'conditionNode';
-  const isGroupsNode = type === 'groupsNode';
+  const isToolsMemoryNode = type === 'toolsMemoryNode';
 
-  // GroupsNode일 경우, 설정에서 그룹 목록 가져오기
+  // ToolsMemoryNode일 경우, 설정에서 그룹 목록 가져오기
   const groups: any[] = data.config?.groups || [];
   const memoryGroups = groups.filter((g: any) => g.type === 'memory');
   const toolsGroups = groups.filter((g: any) => g.type === 'tools');
@@ -98,7 +98,7 @@ export const CustomNode = memo(({ data, isConnectable, selected, id, type }: Nod
       'toolNode': 'bg-green-50 dark:bg-green-900 border-green-200 dark:border-green-700',
       'startNode': 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-600',
       'endNode': 'bg-red-50 dark:bg-red-900 border-red-200 dark:border-red-700',
-      'groupsNode': 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600',
+      'toolsMemoryNode': 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600',
     }[(data.nodeType as string)] || 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-600';
 
     // 조건 노드이고 유효성 에러가 있는 경우 스타일 재정의
@@ -121,7 +121,7 @@ export const CustomNode = memo(({ data, isConnectable, selected, id, type }: Nod
       'toolNode': 'text-green-600 dark:text-green-400 bg-green-100 dark:bg-green-800/50',
       'startNode': 'text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700',
       'endNode': 'text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-800/50',
-      'groupsNode': 'text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700',
+      'toolsMemoryNode': 'text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700',
     }[(data.nodeType as string)] || 'text-gray-600 dark:text-gray-400 bg-gray-100 dark:bg-gray-700';
 
     // 조건 노드이고 유효성 에러가 있는 경우 스타일 재정의
@@ -305,7 +305,7 @@ export const CustomNode = memo(({ data, isConnectable, selected, id, type }: Nod
       }`}
     >
       {/* 시작 노드와 그룹 노드가 아닌 경우 상단 핸들 (입력) 표시 */}
-      {!isStartNode && !isGroupsNode && (
+      {!isStartNode && !isToolsMemoryNode && (
         <Handle
           type="target"
           position={Position.Top}
@@ -317,7 +317,7 @@ export const CustomNode = memo(({ data, isConnectable, selected, id, type }: Nod
       {/* 노드 우측 상단 버튼 (실행, 삭제) */}
       <div className="absolute -top-2 -right-2 flex gap-2">
         {/* End 노드는 실행(재생) 버튼도 숨김 */}
-        {!isGroupsNode && !isEndNode && (
+        {!isToolsMemoryNode && !isEndNode && (
           <div
             className="relative overflow-visible"
             onMouseEnter={() => setIsPlayHovered(true)}
@@ -401,8 +401,8 @@ export const CustomNode = memo(({ data, isConnectable, selected, id, type }: Nod
         <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">{data.description}</div>
       )}
 
-      {/* GroupsNode일 경우 메모리 및 도구 그룹 렌더링 */}
-      {isGroupsNode && (
+      {/* ToolsMemoryNode일 경우 메모리 및 도구 그룹 렌더링 */}
+      {isToolsMemoryNode && (
         <div className="mt-4 space-y-4">
           {renderGroups(memoryGroups, 'memory')}
           {renderGroups(toolsGroups, 'tools')}
@@ -426,7 +426,7 @@ export const CustomNode = memo(({ data, isConnectable, selected, id, type }: Nod
       )}
       
       {/* 종료 노드와 그룹 노드가 아닌 경우 하단 핸들 (출력) 표시 */}
-      {!isEndNode && !isGroupsNode && (
+      {!isEndNode && !isToolsMemoryNode && (
         <Handle
           type="source"
           position={Position.Bottom}

--- a/ui/src/components/nodes/ToolsMemorySettings.tsx
+++ b/ui/src/components/nodes/ToolsMemorySettings.tsx
@@ -1,26 +1,27 @@
 import React, { useState, useEffect } from 'react';
 import { useFlowStore } from '../../store/flowStore';
-import { AlertCircle, ChevronLeft } from 'lucide-react';
+import { AlertCircle, ChevronLeft, Plus, Trash2, Edit2, Check, X } from 'lucide-react';
 import CodeEditor from '../CodeEditor';
-import { Group } from '../../types/node';
+import { Group, NodeData } from '../../types/node';
 
-interface GroupsSettingsProps {
+interface ToolsMemorySettingsProps {
   nodeId: string;
 }
 
-const GroupsSettings: React.FC<GroupsSettingsProps> = ({ nodeId }) => {
+const ToolsMemorySettings: React.FC<ToolsMemorySettingsProps> = ({ nodeId }) => {
   const { nodes, updateNodeData } = useFlowStore();
   const node = nodes.find(n => n.id === nodeId);
   const groups = (node?.data.config?.groups as Group[]) || [];
   const [nameError, setNameError] = useState<string | null>(null);
   
   useEffect(() => {
-    if (node?.data.selectedGroupId) {
-      setSelectedGroupId(node.data.selectedGroupId);
+    const selectedGroupId = (node?.data as NodeData)?.selectedGroupId;
+    if (selectedGroupId) {
+      setSelectedGroupId(selectedGroupId);
     }
-  }, [node?.data.selectedGroupId]);
+  }, [(node?.data as NodeData)?.selectedGroupId]);
 
-  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(node?.data.selectedGroupId || null);
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>((node?.data as NodeData)?.selectedGroupId || null);
   const selectedGroup = groups.find((g: Group) => g.id === selectedGroupId);
 
   const checkNameExists = (name: string, currentGroupId: string): boolean => {
@@ -65,7 +66,7 @@ const GroupsSettings: React.FC<GroupsSettingsProps> = ({ nodeId }) => {
           ...node?.data.config,
           groups: groups.filter(g => g.id !== groupId)
         }
-      });
+      } as NodeData);
       setSelectedGroupId(null);
     }
   };
@@ -75,7 +76,7 @@ const GroupsSettings: React.FC<GroupsSettingsProps> = ({ nodeId }) => {
     updateNodeData(nodeId, {
       ...node?.data,
       selectedGroupId: null
-    });
+    } as NodeData);
   };
 
   if (!selectedGroup) {
@@ -176,4 +177,4 @@ const GroupsSettings: React.FC<GroupsSettingsProps> = ({ nodeId }) => {
   );
 };
 
-export default GroupsSettings;
+export default ToolsMemorySettings;

--- a/ui/src/components/nodes/nodeTypes.tsx
+++ b/ui/src/components/nodes/nodeTypes.tsx
@@ -4,7 +4,6 @@ import {
   Database, Cpu
 } from 'lucide-react';
 import { CustomNode } from './CustomNode';
-
 const AgentNode = (props: any) => (
   <CustomNode 
     {...props}
@@ -89,14 +88,14 @@ const SystemPromptNode = (props: any) => (
   />
 );
 
-const GroupsNode = (props: any) => (
+const ToolsMemoryNode = (props: any) => (
   <CustomNode 
     {...props}
     data={{
       ...props.data,
       icon: <Group size={16} />,
-      nodeType: 'groupsNode',
-      description: 'Organize and manage node groups'
+      nodeType: 'toolsMemoryNode',
+      description: 'Tools and Memory groups management'
     }}
   />
 );
@@ -145,7 +144,7 @@ export const nodeTypes = {
   endNode: EndNode,
   promptNode: PromptNode,
   systemPromptNode: SystemPromptNode,
-  groupsNode: GroupsNode,
+  toolsMemoryNode: ToolsMemoryNode,
   embeddingNode: EmbeddingNode,
   ragNode: RAGNode,
   mergeNode: MergeNode, // MergeNode 추가

--- a/ui/src/data/nodeCategories.tsx
+++ b/ui/src/data/nodeCategories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { 
   Bot, Split, FileCode, MessageSquare, Settings, Group, GitMerge,
-  Database, Cpu
+  Database, Cpu, FolderOpen
 } from 'lucide-react';
 
 export interface NodeItem {
@@ -53,10 +53,10 @@ export const nodeCategories: NodeCategory[] = [
         icon: (className = '') => <FileCode size={20} className={className} />
       },
       {
-        type: 'groupsNode',
-        label: 'Groups',
-        description: 'Organize and manage node groups',
-        icon: (className = '') => <Group size={20} className={className} />
+        type: 'toolsMemoryNode',
+        label: 'Tools&Memory',
+        description: 'Tools and Memory groups management',
+        icon: (className = '') => <FolderOpen className="w-5 h-5" />
       },
       {
         type: 'mergeNode',

--- a/ui/src/store/flowStore.ts
+++ b/ui/src/store/flowStore.ts
@@ -814,9 +814,9 @@ export const useFlowStore = create<FlowState>((set, get) => ({
           if (selectedToolIds.length > 0) {
             // 이 부분은 로그 출력을 위한 것이므로 API 페이로드 구성과는 별개입니다.
             console.log(`[AgentNode ${nodeId}] --- 🛠️ Tool 상세 정보 시작 ---`);
-            const groupsNode = get().nodes.find(n => n.type === 'groupsNode');
-            if (groupsNode && groupsNode.data.config?.groups) {
-              const allGroups = groupsNode.data.config.groups as Array<{ id: string; name: string; type: string; description?: string; code?: string; [key: string]: any }>;
+            const toolsMemoryNode = get().nodes.find(n => n.type === 'toolsMemoryNode');
+            if (toolsMemoryNode && toolsMemoryNode.data.config?.groups) {
+              const allGroups = toolsMemoryNode.data.config.groups as Array<{ id: string; name: string; type: string; description?: string; code?: string; [key: string]: any }>;
               
               selectedToolIds.forEach(toolId => {
                 const toolGroup = allGroups.find(g => g.id === toolId);
@@ -826,11 +826,11 @@ export const useFlowStore = create<FlowState>((set, get) => ({
                   console.log(`[AgentNode ${nodeId}]     - 설명 (Description): ${toolGroup.description || 'N/A'}`);
                   console.log(`[AgentNode ${nodeId}]     - Python 코드 (Code): \n${toolGroup.code || 'N/A'}`);
                 } else {
-                  console.warn(`[AgentNode ${nodeId}]   ⚠️ 경고: 선택된 Tool ID '${toolId}'에 해당하는 그룹을 GroupsNode에서 찾을 수 없습니다.`);
+                  console.warn(`[AgentNode ${nodeId}]   ⚠️ 경고: 선택된 Tool ID '${toolId}'에 해당하는 그룹을 toolsMemoryNode에서 찾을 수 없습니다.`);
                 }
               });
             } else {
-              console.warn(`[AgentNode ${nodeId}]   ⚠️ 경고: GroupsNode를 찾을 수 없거나 그룹 데이터가 없어 Tool 상세 정보를 로드할 수 없습니다.`);
+              console.warn(`[AgentNode ${nodeId}]   ⚠️ 경고: toolsMemoryNode를 찾을 수 없거나 그룹 데이터가 없어 Tool 상세 정보를 로드할 수 없습니다.`);
             }
             console.log(`[AgentNode ${nodeId}] --- 🛠️ Tool 상세 정보 종료 ---`);
           } else {
@@ -898,9 +898,9 @@ export const useFlowStore = create<FlowState>((set, get) => ({
           let memoryTypeForAPI: string | undefined = undefined;
           let memoryGroupNameForAPI: string | undefined = undefined; // 메모리 그룹 이름을 저장할 변수
           if (memoryGroup) { // memoryGroup is the ID of the selected group
-            const groupsNode = get().nodes.find(n => n.type === 'groupsNode');
-            if (groupsNode && groupsNode.data.config?.groups) {
-              const allGroups = groupsNode.data.config.groups as Array<{ id: string; name: string; type: string; memoryType?: string; [key: string]: any }>;
+            const toolsMemoryNode = get().nodes.find(n => n.type === 'toolsMemoryNode');
+            if (toolsMemoryNode && toolsMemoryNode.data.config?.groups) {
+              const allGroups = toolsMemoryNode.data.config.groups as Array<{ id: string; name: string; type: string; memoryType?: string; [key: string]: any }>;
               const selectedGroupDetails = allGroups.find(g => g.id === memoryGroup);
               if (selectedGroupDetails && selectedGroupDetails.type === 'memory') {
                 // groupsNode에 저장된 memoryType 값을 우선 사용합니다.
@@ -924,9 +924,9 @@ export const useFlowStore = create<FlowState>((set, get) => ({
           // API 페이로드용 tools_for_api 구성
           let tools_for_api: Array<{ tool_name: string; tool_description: string; tool_code: string }> = []; // 'python_code' -> 'tool_code'로 변경
           if (selectedToolIds.length > 0) {
-            const groupsNode = get().nodes.find(n => n.type === 'groupsNode');
-            if (groupsNode && groupsNode.data.config?.groups) {
-              const allGroups = groupsNode.data.config.groups as Array<{ id: string; name: string; type: string; description?: string; code?: string; [key: string]: any }>;
+            const toolsMemoryNode = get().nodes.find(n => n.type === 'toolsMemoryNode');
+            if (toolsMemoryNode && toolsMemoryNode.data.config?.groups) {
+              const allGroups = toolsMemoryNode.data.config.groups as Array<{ id: string; name: string; type: string; description?: string; code?: string; [key: string]: any }>;
               selectedToolIds.forEach(toolId => {
                 const toolGroup = allGroups.find(g => g.id === toolId);
                 if (toolGroup && toolGroup.type === 'tools') { // groupsNode에서 가져온 그룹이 'tools' 타입인지 확인
@@ -936,11 +936,11 @@ export const useFlowStore = create<FlowState>((set, get) => ({
                     tool_code: toolGroup.code || '' // 'python_code' -> 'tool_code'로 변경
                   });
                 } else {
-                  console.warn(`[AgentNode ${nodeId}] API Payload: Tool ID '${toolId}'에 해당하는 Tool 정보를 GroupsNode에서 찾을 수 없거나 타입이 'tools'가 아닙니다. API 요청에서 제외됩니다.`);
+                  console.warn(`[AgentNode ${nodeId}] API Payload: Tool ID '${toolId}'에 해당하는 Tool 정보를 toolsMemoryNode에서 찾을 수 없거나 타입이 'tools'가 아닙니다. API 요청에서 제외됩니다.`);
                 }
               });
             } else {
-              console.warn(`[AgentNode ${nodeId}] API Payload: GroupsNode를 찾을 수 없거나 그룹 데이터가 없어 Tool 정보를 API 페이로드에 포함할 수 없습니다.`);
+              console.warn(`[AgentNode ${nodeId}] API Payload: toolsMemoryNode를 찾을 수 없거나 그룹 데이터가 없어 Tool 정보를 API 페이로드에 포함할 수 없습니다.`);
             }
           }
 
@@ -1386,10 +1386,51 @@ export const useFlowStore = create<FlowState>((set, get) => ({
           } else {
             modelConfigForExport.apiKey = modelDetails.apiKey;
           }
-          // 변환된 객체로 기존 config.model을 대체합니다.
+          
+          // Memory Group 정보를 실제 구성 정보로 변환
+          let memoryConfigForExport: any = undefined;
+          if (finalNodeData.config?.memoryGroup) {
+            const toolsMemoryNode = nodes.find(n => n.type === 'toolsMemoryNode');
+            if (toolsMemoryNode && toolsMemoryNode.data.config?.groups) {
+              const allGroups = toolsMemoryNode.data.config.groups as Array<{ id: string; name: string; type: string; description?: string; memoryType?: string; [key: string]: any }>;
+              const selectedMemoryGroup = allGroups.find(g => g.id === finalNodeData.config!.memoryGroup && g.type === 'memory');
+              if (selectedMemoryGroup) {
+                memoryConfigForExport = {
+                  id: selectedMemoryGroup.id,
+                  name: selectedMemoryGroup.name,
+                  description: selectedMemoryGroup.description || '',
+                  memoryType: selectedMemoryGroup.memoryType || 'ConversationBufferMemory'
+                };
+              }
+            }
+          }
+
+          // Tools 정보를 실제 구성 정보로 변환
+          let toolsConfigForExport: Array<{ id: string; name: string; description: string; code: string }> = [];
+          if (finalNodeData.config?.tools && Array.isArray(finalNodeData.config.tools)) {
+            const toolsMemoryNode = nodes.find(n => n.type === 'toolsMemoryNode');
+            if (toolsMemoryNode && toolsMemoryNode.data.config?.groups) {
+              const allGroups = toolsMemoryNode.data.config.groups as Array<{ id: string; name: string; type: string; description?: string; code?: string; [key: string]: any }>;
+              finalNodeData.config.tools.forEach((toolId: string) => {
+                const selectedToolGroup = allGroups.find(g => g.id === toolId && g.type === 'tools');
+                if (selectedToolGroup) {
+                  toolsConfigForExport.push({
+                    id: selectedToolGroup.id,
+                    name: selectedToolGroup.name,
+                    description: selectedToolGroup.description || '',
+                    code: selectedToolGroup.code || ''
+                  });
+                }
+              });
+            }
+          }
+
+          // 변환된 객체로 기존 config를 대체합니다.
           finalNodeData.config = {
             ...finalNodeData.config,
             model: modelConfigForExport,
+            memoryGroup: memoryConfigForExport, // ID 대신 실제 구성 정보
+            tools: toolsConfigForExport, // ID 배열 대신 실제 구성 정보 배열
           };
         }
       }


### PR DESCRIPTION
✅ 노드 타입: groupsNode → toolsMemoryNode
✅ 노드 이름: "Groups" → "Tools&Memory"
✅ 파일명: GroupsSettings.tsx → ToolsMemorySettings.tsx
✅ 컴포넌트명: GroupsSettings → ToolsMemorySettings
✅ 모든 참조 위치 업데이트
✅ Export Python 시 실제 구성 정보 포함
✅ 불필요한 import 문 정리

🔧 기술적 세부사항
Frontend만 수정: Server 코드는 건드리지 않음
타입 안전성: TypeScript 타입 체크 유지
기존 기능 보존: 모든 기존 기능이 정상 동작
UI/UX 개선: 더 직관적인 노드 이름과 설명
이제 Export Python 버튼을 클릭하면 Agent 노드의 Memory와 Tools 정보가 실제 구성 정보(이름, 설명, 유형, 코드 등)로 포함되어 전송


Related to : #61 #10 