### PR TITLE
feat: Agent 노드 메모리 UI 설정 변경 및 커스텀 Select Box 구현 및 적용

### DIFF
--- a/ui/src/components/Common/CustomSelect.tsx
+++ b/ui/src/components/Common/CustomSelect.tsx
@@ -1,0 +1,127 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { ChevronDown, Check } from 'lucide-react';
+
+interface CustomSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: { value: string; label: string }[];
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const CustomSelect: React.FC<CustomSelectProps> = ({
+  value,
+  onChange,
+  options,
+  placeholder = 'Select...',
+  disabled = false,
+}) => {
+  const [open, setOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const selected = options.find(opt => opt.value === value) || null;
+  const [highlightedIdx, setHighlightedIdx] = useState<number>(-1);
+
+  const allOptions = [{ value: '', label: placeholder }, ...options];
+
+  // 외부 클릭 시 닫힘
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (
+        buttonRef.current && !buttonRef.current.contains(e.target as Node) &&
+        listRef.current && !listRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  // 키보드 접근성
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        setHighlightedIdx(idx => Math.min(options.length - 1, idx + 1));
+        e.preventDefault();
+      } else if (e.key === 'ArrowUp') {
+        setHighlightedIdx(idx => Math.max(0, idx - 1));
+        e.preventDefault();
+      } else if (e.key === 'Enter') {
+        if (highlightedIdx >= 0 && highlightedIdx < options.length) {
+          onChange(options[highlightedIdx].value);
+          setOpen(false);
+        }
+      } else if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, highlightedIdx, options, onChange]);
+
+  useEffect(() => {
+    if (open) {
+      // 선택된 값이 있으면 해당 인덱스 하이라이트
+      const idx = options.findIndex(opt => opt.value === value);
+      setHighlightedIdx(idx >= 0 ? idx : 0);
+    }
+  }, [open, value, options]);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        ref={buttonRef}
+        disabled={disabled}
+        className={`w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-sm flex justify-between items-center focus:outline-none focus:ring-2 focus:ring-blue-500 transition ${disabled ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'} ${selected ? 'text-gray-900 dark:text-gray-100' : 'text-gray-400 dark:text-gray-500'}`}
+        onClick={() => !disabled && setOpen(o => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <span className={selected ? '' : 'text-gray-400 dark:text-gray-500'}>
+          {selected ? selected.label : placeholder}
+        </span>
+        <ChevronDown size={18} className="ml-2 text-gray-400 dark:text-gray-500" />
+      </button>
+      {open && (
+        <div
+          ref={listRef}
+          className="absolute z-20 mt-1 w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg max-h-60 overflow-auto animate-fade-in"
+          tabIndex={-1}
+          role="listbox"
+        >
+          {allOptions.length === 0 && (
+            <div className="px-4 py-2 text-gray-400 dark:text-gray-500 text-sm">No options</div>
+          )}
+          {allOptions.map((opt, idx) => {
+            const isPlaceholder = opt.value === '';
+            return (
+              <div
+                key={opt.value + idx}
+                role="option"
+                aria-selected={value === opt.value}
+                className={`px-4 py-2 cursor-pointer text-sm flex items-center transition-colors
+                  ${value === opt.value ? 'font-semibold text-blue-700 dark:text-blue-300' : ''}
+                  ${highlightedIdx === idx ? 'bg-blue-100 dark:bg-blue-900/40' : ''}
+                  ${isPlaceholder ? 'text-gray-400 dark:text-gray-500' : 'text-gray-900 dark:text-gray-100'}`}
+                onClick={() => {
+                  onChange(opt.value);
+                  setOpen(false);
+                }}
+                onMouseEnter={() => setHighlightedIdx(idx)}
+              >
+                {value === opt.value && <Check size={16} className="mr-2 text-blue-600 dark:text-blue-300" />}
+                {opt.label}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CustomSelect; 

--- a/ui/src/components/nodes/ChatHistorySettings.tsx
+++ b/ui/src/components/nodes/ChatHistorySettings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useFlowStore } from '../../store/flowStore';
 import { AlertCircle } from 'lucide-react';
+import CustomSelect from '../Common/CustomSelect';
 
 interface ChatHistorySettingsProps {
   nodeId: string;
@@ -68,21 +69,13 @@ const ChatHistorySettings: React.FC<ChatHistorySettingsProps> = ({ nodeId }) => 
           <label className="block text-sm font-medium text-gray-600">
             Role Variable
           </label>
-          <select
+          <CustomSelect
             value={node?.data.config?.roleVariable || ''}
-            onChange={(e) => handleRoleVariableChange(e.target.value)}
-            className={`w-full px-3 py-2 border ${
-              !hasValidOutput ? 'bg-gray-50 text-gray-400' : 'bg-white'
-            } border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm`}
+            onChange={handleRoleVariableChange}
+            options={hasValidOutput ? Object.keys(sourceOutput).map(variable => ({ value: variable, label: variable })) : []}
+            placeholder="Select role variable"
             disabled={!hasValidOutput}
-          >
-            <option value="">Select role variable</option>
-            {hasValidOutput && Object.keys(sourceOutput).map((variable) => (
-              <option key={variable} value={variable}>
-                {variable}
-              </option>
-            ))}
-          </select>
+          />
           {!incomingEdge && (
             <div className="flex items-center mt-1 text-amber-500 text-xs">
               <AlertCircle size={12} className="mr-1" />
@@ -95,21 +88,13 @@ const ChatHistorySettings: React.FC<ChatHistorySettingsProps> = ({ nodeId }) => 
           <label className="block text-sm font-medium text-gray-600">
             Content Variable
           </label>
-          <select
+          <CustomSelect
             value={node?.data.config?.contentVariable || ''}
-            onChange={(e) => handleContentVariableChange(e.target.value)}
-            className={`w-full px-3 py-2 border ${
-              !hasValidOutput ? 'bg-gray-50 text-gray-400' : 'bg-white'
-            } border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm`}
+            onChange={handleContentVariableChange}
+            options={hasValidOutput ? Object.keys(sourceOutput).map(variable => ({ value: variable, label: variable })) : []}
+            placeholder="Select content variable"
             disabled={!hasValidOutput}
-          >
-            <option value="">Select content variable</option>
-            {hasValidOutput && Object.keys(sourceOutput).map((variable) => (
-              <option key={variable} value={variable}>
-                {variable}
-              </option>
-            ))}
-          </select>
+          />
         </div>
       </div>
 

--- a/ui/src/components/nodes/CustomNode.tsx
+++ b/ui/src/components/nodes/CustomNode.tsx
@@ -222,7 +222,8 @@ export const CustomNode = memo(({ data, isConnectable, selected, id, type }: Nod
       name: newName,
       description: '',
       nodes: [],
-      type
+      type,
+      ...(type === 'memory' && { memoryType: 'ConversationBufferMemory' }) // memory 그룹일 때만 기본값 추가
     };
     // 노드 데이터 업데이트 (새 그룹 추가)
     updateNodeData(id, {

--- a/ui/src/components/nodes/EmbeddingSettings.tsx
+++ b/ui/src/components/nodes/EmbeddingSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useFlowStore } from '../../store/flowStore';
 import { AlertCircle, Pencil, Check } from 'lucide-react';
+import CustomSelect from '../Common/CustomSelect';
 
 interface EmbeddingSettingsProps {
   nodeId: string;
@@ -106,28 +107,18 @@ const EmbeddingSettings: React.FC<EmbeddingSettingsProps> = ({ nodeId }) => {
                 </>
               ) : (
                 <>
-                  <select
-                    id="embeddingOutputVariableSelect"
+                  <CustomSelect
                     value={node?.data.config?.outputVariable || ''}
-                    onChange={(e) => handleOutputVariableChange(e.target.value)}
-                    className={`flex-grow px-3 py-2 border ${
-                      !hasValidOutput && availableVariables.length === 0 ? 'bg-gray-50 dark:bg-gray-700 text-gray-400 dark:text-gray-500' : 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
-                    } border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm`}
+                    onChange={handleOutputVariableChange}
+                    options={[
+                      ...(node?.data.config?.outputVariable && !availableVariables.includes(node.data.config.outputVariable)
+                        ? [{ value: node.data.config.outputVariable, label: `${node.data.config.outputVariable} (Custom)` }]
+                        : []),
+                      ...availableVariables.map(variable => ({ value: variable, label: variable }))
+                    ]}
+                    placeholder="Select output variable"
                     disabled={!hasValidOutput && availableVariables.length === 0 && !node?.data.config?.outputVariable}
-                  >
-                    <option value="">Select output variable</option>
-                    {node?.data.config?.outputVariable && 
-                     !availableVariables.includes(node.data.config.outputVariable) && (
-                      <option value={node.data.config.outputVariable}>
-                        {node.data.config.outputVariable} (Custom)
-                      </option>
-                    )}
-                    {availableVariables.map((variable) => (
-                      <option key={variable} value={variable}>
-                        {variable}
-                      </option>
-                    ))}
-                  </select>
+                  />
                   <button onClick={() => setIsEditingOutputVariable(true)} className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md flex-shrink-0" aria-label="Edit output variable">
                     <Pencil size={18} />
                   </button>
@@ -142,18 +133,13 @@ const EmbeddingSettings: React.FC<EmbeddingSettingsProps> = ({ nodeId }) => {
           <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">
             Embedding Model
           </label>
-          <select
-            value={node?.data.config?.model || ''}
-            onChange={(e) => handleModelChange(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-          >
-            <option value="">Select a model</option>
-            {mockEmbeddingModels.map(conn => (
-              <option key={conn.id} value={conn.model}>
-                {conn.name} ({conn.provider})
-              </option>
-            ))}
-          </select>
+          <CustomSelect
+            value={typeof node?.data.config?.model === 'string' ? node.data.config.model : ''}
+            onChange={handleModelChange}
+            options={mockEmbeddingModels.map(conn => ({ value: conn.model, label: `${conn.name} (${conn.provider})` }))}
+            placeholder="Select a model"
+            disabled={mockEmbeddingModels.length === 0}
+          />
           {mockEmbeddingModels.length === 0 && (
             <p className="text-xs text-amber-500 dark:text-amber-400">
               No embedding models configured. Please add models in the RAG Configuration section.

--- a/ui/src/components/nodes/EndNodeSettings.tsx
+++ b/ui/src/components/nodes/EndNodeSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useFlowStore, NodeData } from '../../store/flowStore';
 import { AlertCircle } from 'lucide-react'; // 아이콘 import
+import CustomSelect from '../Common/CustomSelect';
 
 interface EndNodeSettingsProps {
   nodeId: string;
@@ -78,11 +79,9 @@ const EndNodeSettings: React.FC<EndNodeSettingsProps> = ({ nodeId }) => {
     }
   }, [currentNode, nodeId, edges, updateDisplayedValue]); // 의존성 배열에 nodeId, edges, updateDisplayedValue 추가
 
-  const handleSelectedKeyChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newKey = e.target.value;
+  const handleSelectedKeyChange = (newKey: string) => {
     setSelectedKeyName(newKey);
     debouncedUpdateNodeData({ config: { ...currentNode?.data.config, receiveKey: newKey } });
-    
     // 선택 변경 시 즉시 표시 값 업데이트 (mergedInputFromEdges 사용)
     const incomingEdges = edges.filter(edge => edge.target === nodeId);
     const currentMergedInput = incomingEdges.reduce((acc, edge) => {
@@ -100,22 +99,13 @@ const EndNodeSettings: React.FC<EndNodeSettingsProps> = ({ nodeId }) => {
     <div className="space-y-4">
       <div>
         <label htmlFor="endnode-select-key" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Chatbot Output Key</label>
-        <select
-          id="endnode-select-key"
+        <CustomSelect
           value={selectedKeyName}
           onChange={handleSelectedKeyChange}
-          className={`w-full px-3 py-2 border \
-            ${availableKeys.length === 0 
-              ? 'bg-gray-50 text-gray-400 dark:bg-gray-800 dark:text-gray-500' 
-              : 'bg-white dark:bg-gray-700 dark:text-gray-100'} \
-            border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500`}
+          options={availableKeys.map(key => ({ value: key, label: key }))}
+          placeholder="-- Select a key --"
           disabled={availableKeys.length === 0}
-        >
-          <option value="">-- Select a key --</option>
-          {availableKeys.map(key => (
-            <option key={key} value={key}>{key}</option>
-          ))}
-        </select>
+        />
         {(() => {
           const hasIncomingEdges = edges.some(edge => edge.target === nodeId);
           if (!hasIncomingEdges) {

--- a/ui/src/components/nodes/MergeSettings.tsx
+++ b/ui/src/components/nodes/MergeSettings.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { useFlowStore } from '../../store/flowStore';
 import { PlusCircle, Trash2 } from 'lucide-react';
 import { nanoid } from 'nanoid';
+import CustomSelect from '../Common/CustomSelect';
 
 interface MergeMapping {
   id: string;
@@ -119,19 +120,12 @@ const MergeSettings: React.FC<MergeSettingsProps> = ({ nodeId }) => {
           {/* Source Value 선택 드롭다운 */}
           <div>
             <label htmlFor={`source-value-${mapping.id}`} className="block text-xs font-medium text-gray-600 dark:text-gray-300 mb-0.5">Source Value</label>
-            <select
-              id={`source-value-${mapping.id}`}
+            <CustomSelect
               value={mapping.sourceNodeId ? `${mapping.sourceNodeId}.${mapping.sourceNodeKey}` : ''}
-              onChange={(e) => handleMappingChange(index, 'sourceNodeId', e.target.value)} // 'sourceNodeId' is a placeholder, actual logic splits it
-              className="w-full px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-            >
-              <option value="">Select Source Value</option>
-              {availableSourceOptions.map(opt => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+              onChange={value => handleMappingChange(index, 'sourceNodeId', value)}
+              options={availableSourceOptions}
+              placeholder="Select Source Value"
+            />
           </div>
           {/* 삭제 버튼 */}
           <div className="flex justify-end">

--- a/ui/src/components/nodes/PromptSettings.tsx
+++ b/ui/src/components/nodes/PromptSettings.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import CodeEditor from '../CodeEditor';
 import { useFlowStore } from '../../store/flowStore';
 import { AlertCircle, Pencil, Check } from 'lucide-react';
+import CustomSelect from '../Common/CustomSelect';
 
 interface PromptSettingsProps {
   nodeId: string;
@@ -86,30 +87,18 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
                   </>
                 ) : (
                   <>
-                    <select
-                      id="promptOutputVariableSelect"
+                    <CustomSelect
                       value={node?.data.config?.outputVariable || ''}
-                      onChange={(e) => handleOutputVariableChange(e.target.value)}
-                      className={`flex-grow px-3 py-2 border ${
-                        !hasValidOutput && availableVariables.length === 0 
-                          ? 'bg-gray-50 dark:bg-gray-700 text-gray-400 dark:text-gray-500' 
-                          : 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
-                      } border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm`}
+                      onChange={handleOutputVariableChange}
+                      options={[
+                        ...(node?.data.config?.outputVariable && !availableVariables.includes(node.data.config.outputVariable)
+                          ? [{ value: node.data.config.outputVariable, label: `${node.data.config.outputVariable} (Custom)` }]
+                          : []),
+                        ...availableVariables.map(variable => ({ value: variable, label: variable }))
+                      ]}
+                      placeholder="Select output variable"
                       disabled={!hasValidOutput && availableVariables.length === 0 && !node?.data.config?.outputVariable}
-                    >
-                      <option value="">Select output variable</option>
-                      {node?.data.config?.outputVariable && 
-                       !availableVariables.includes(node.data.config.outputVariable) && (
-                        <option value={node.data.config.outputVariable}>
-                          {node.data.config.outputVariable} (Custom)
-                        </option>
-                      )}
-                      {availableVariables.map((variable) => (
-                        <option key={variable} value={variable}>
-                          {variable}
-                        </option>
-                      ))}
-                    </select>
+                    />
                     <button onClick={() => setIsEditingOutputVariable(true)} className="p-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md flex-shrink-0" aria-label="Edit output variable">
                       <Pencil size={18} />
                     </button>

--- a/ui/src/components/nodes/RAGSettings.tsx
+++ b/ui/src/components/nodes/RAGSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useFlowStore } from '../../store/flowStore';
 import { AlertCircle, Pencil, Check } from 'lucide-react';
+import CustomSelect from '../Common/CustomSelect';
 
 interface RAGSettingsProps {
   nodeId: string;
@@ -146,18 +147,13 @@ const RAGSettings: React.FC<RAGSettingsProps> = ({ nodeId }) => {
           <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">
             RAG Configuration
           </label>
-          <select
+          <CustomSelect
             value={node?.data.config?.ragConfig || ''}
-            onChange={(e) => handleConfigChange(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-          >
-            <option value="">Select a RAG configuration</option>
-            {mockRAGConfigs.map((config) => (
-              <option key={config.id} value={config.id}>
-                {config.name} ({config.vectorDb})
-              </option>
-            ))}
-          </select>
+            onChange={handleConfigChange}
+            options={mockRAGConfigs.map(config => ({ value: config.id, label: `${config.name} (${config.vectorDb})` }))}
+            placeholder="Select a RAG configuration"
+            disabled={mockRAGConfigs.length === 0}
+          />
           {mockRAGConfigs.length === 0 && (
             <p className="text-xs text-amber-500 dark:text-amber-400">
               No RAG configurations found. Please set up RAG in the RAG Configuration section.

--- a/ui/src/components/nodes/StartSettings.tsx
+++ b/ui/src/components/nodes/StartSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useFlowStore } from '../../store/flowStore';
 import { Plus, X, AlertCircle } from 'lucide-react';
+import CustomSelect from '../Common/CustomSelect';
 
 interface Variable {
   name: string;
@@ -115,14 +116,15 @@ const StartSettings: React.FC<StartSettingsProps> = ({ nodeId }) => {
           <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">
             Class Type
           </label>
-          <select
+          <CustomSelect
             value={classType}
-            onChange={(e) => handleClassTypeChange(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-          >
-            <option value="TypedDict">TypedDict</option>
-            <option value="BaseModel">BaseModel</option>
-          </select>
+            onChange={handleClassTypeChange}
+            options={[
+              { value: 'TypedDict', label: 'TypedDict' },
+              { value: 'BaseModel', label: 'BaseModel' }
+            ]}
+            placeholder="Select class type"
+          />
         </div>
       </div>
 
@@ -176,17 +178,18 @@ const StartSettings: React.FC<StartSettingsProps> = ({ nodeId }) => {
                   <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">
                     Variable Type
                   </label>
-                  <select
+                  <CustomSelect
                     value={variable.type}
-                    onChange={(e) => handleVariableChange(index, 'type', e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-                  >
-                    <option value="string">string</option>
-                    <option value="int">int</option>
-                    <option value="float">float</option>
-                    <option value="list">list</option>
-                    <option value="dict">dict</option>
-                  </select>
+                    onChange={value => handleVariableChange(index, 'type', value)}
+                    options={[
+                      { value: 'string', label: 'string' },
+                      { value: 'int', label: 'int' },
+                      { value: 'float', label: 'float' },
+                      { value: 'list', label: 'list' },
+                      { value: 'dict', label: 'dict' }
+                    ]}
+                    placeholder="Select variable type"
+                  />
                 </div>
 
                 <div className="space-y-2">
@@ -206,15 +209,16 @@ const StartSettings: React.FC<StartSettingsProps> = ({ nodeId }) => {
                   <label className="block text-sm font-medium text-gray-600 dark:text-gray-300">
                     Select Variable
                   </label>
-                  <select
+                  <CustomSelect
                     value={variable.selectVariable}
-                    onChange={(e) => handleVariableChange(index, 'selectVariable', e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-                  >
-                    <option value="">None</option>
-                    <option value="question">question</option>
-                    <option value="chat_history">chat_history</option>
-                  </select>
+                    onChange={value => handleVariableChange(index, 'selectVariable', value)}
+                    options={[
+                      { value: '', label: 'None' },
+                      { value: 'question', label: 'question' },
+                      { value: 'chat_history', label: 'chat_history' }
+                    ]}
+                    placeholder="Select variable"
+                  />
                 </div>
               </div>
             </div>

--- a/ui/src/components/nodes/SystemPromptSettings.tsx
+++ b/ui/src/components/nodes/SystemPromptSettings.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import CodeEditor from '../CodeEditor';
 import { useFlowStore } from '../../store/flowStore';
 import { AlertCircle } from 'lucide-react';
+import CustomSelect from '../Common/CustomSelect';
 
 interface SystemPromptSettingsProps {
   nodeId: string;
@@ -47,23 +48,13 @@ const SystemPromptSettings: React.FC<SystemPromptSettingsProps> = ({ nodeId }) =
               Output Variable
             </label>
             <div className="relative">
-              <select
+              <CustomSelect
                 value={node?.data.config?.outputVariable || ''}
-                onChange={(e) => handleOutputVariableChange(e.target.value)}
-                className={`w-full px-3 py-2 border ${
-                  !hasValidOutput 
-                    ? 'bg-gray-50 dark:bg-gray-700 text-gray-400 dark:text-gray-500' 
-                    : 'bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100'
-                } border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm`}
+                onChange={handleOutputVariableChange}
+                options={availableVariables.map(variable => ({ value: variable, label: variable }))}
+                placeholder="Select output variable"
                 disabled={!hasValidOutput}
-              >
-                <option value="">Select output variable</option>
-                {availableVariables.map((variable) => (
-                  <option key={variable} value={variable}>
-                    {variable}
-                  </option>
-                ))}
-              </select>
+              />
               {!incomingEdge && (
                 <div className="flex items-center mt-1 text-amber-500 text-xs">
                   <AlertCircle size={12} className="mr-1" />

--- a/ui/src/components/nodes/ToolsMemorySettings.tsx
+++ b/ui/src/components/nodes/ToolsMemorySettings.tsx
@@ -3,6 +3,7 @@ import { useFlowStore } from '../../store/flowStore';
 import { AlertCircle, ChevronLeft, Plus, Trash2, Edit2, Check, X } from 'lucide-react';
 import CodeEditor from '../CodeEditor';
 import { Group, NodeData } from '../../types/node';
+import CustomSelect from '../Common/CustomSelect';
 
 interface ToolsMemorySettingsProps {
   nodeId: string;
@@ -131,16 +132,15 @@ const ToolsMemorySettings: React.FC<ToolsMemorySettingsProps> = ({ nodeId }) => 
               <label className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
                 Memory Type
               </label>
-              <select
+              <CustomSelect
                 value={selectedGroup.memoryType || 'ConversationBufferMemory'}
-                onChange={(e) => handleUpdateGroup(selectedGroup.id, { 
-                  memoryType: e.target.value as 'ConversationBufferMemory' | 'ConversationBufferWindowMemory' 
-                })}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-              >
-                <option value="ConversationBufferMemory">Conversation Buffer Memory</option>
-                <option value="ConversationBufferWindowMemory">Conversation Buffer Window Memory</option>
-              </select>
+                onChange={value => handleUpdateGroup(selectedGroup.id, { memoryType: value as 'ConversationBufferMemory' | 'ConversationBufferWindowMemory' })}
+                options={[
+                  { value: 'ConversationBufferMemory', label: 'Conversation Buffer Memory' },
+                  { value: 'ConversationBufferWindowMemory', label: 'Conversation Buffer Window Memory' }
+                ]}
+                placeholder="Select memory type"
+              />
             </div>
           )}
 


### PR DESCRIPTION
## 1. 공통 커스텀 드랍박스 컴포넌트(CustomSelect) 구현
- React + Tailwind만으로 완전 커스텀 드랍다운(팝오버) 컴포넌트 제작
- 다크모드, placeholder, 외부 클릭 닫힘, 키보드 접근성, 초기화(빈값) 등 지원
![image](https://github.com/user-attachments/assets/47d3712d-03a7-4114-9575-aff59bff9b50)


## 2. 다른 노드(시작, 종료, 프롬프트, 임베딩, RAG, Merge, ToolsMemory, ChatHistory 등)에도 CustomSelect 일괄 적용
- 기존 `<select>`를 모두 CustomSelect로 교체하여 UI/UX 일관성 확보

## 3. 다크모드에서 드랍다운 글자색 개선
- placeholder, 옵션, 선택 강조 등 다크모드에서 가독성 높게 스타일링
![image](https://github.com/user-attachments/assets/e51c1d1b-f5e9-4a8f-a08e-406597a5a1a3)
![image](https://github.com/user-attachments/assets/2e1a9e1b-1f1a-4b93-b62c-c239ab64c38d)


## 4. 드랍다운 placeholder를 옵션처럼 리스트 맨 위에 노출
- 선택 시 value가 빈 문자열이 되어 초기화 역할 수행

## 6. Agent 노드 메모리 설정 UI 변경
- 선택시 모델 설정과 유사하게 정보를 표시 되게 기능 추가
![image](https://github.com/user-attachments/assets/592b5981-801f-4f4b-9af0-e4e6dcfa60b4)


---

### ✅ 결과
- **Agent 노드 메모리 설정 정보표시 UI 개선**
- **모든 노드 설정에서 드랍박스 UI/UX가 완전히 통일**
- **다크모드, 접근성, 초기화, 커스텀 옵션 등 최신 UX 적용**


Related to : #65 