### PR TITLE
chore: Tools&Memory 노드의 그룹 생성 시 생기는 뒤로가기 기능 제거

### DIFF
--- a/ui/src/components/nodes/ToolsMemorySettings.tsx
+++ b/ui/src/components/nodes/ToolsMemorySettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useFlowStore } from '../../store/flowStore';
-import { AlertCircle, ChevronLeft, Plus, Trash2, Edit2, Check, X } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
 import CodeEditor from '../CodeEditor';
 import { Group, NodeData } from '../../types/node';
 
@@ -71,14 +71,6 @@ const ToolsMemorySettings: React.FC<ToolsMemorySettingsProps> = ({ nodeId }) => 
     }
   };
 
-  const handleBack = () => {
-    setSelectedGroupId(null);
-    updateNodeData(nodeId, {
-      ...node?.data,
-      selectedGroupId: null
-    } as NodeData);
-  };
-
   if (!selectedGroup) {
     return null;
   }
@@ -87,13 +79,7 @@ const ToolsMemorySettings: React.FC<ToolsMemorySettingsProps> = ({ nodeId }) => 
     <div className="h-full flex flex-col">
       <div className="p-4 border-b border-gray-200 dark:border-gray-700">
         <div className="flex items-center justify-between mb-4">
-          <button
-            onClick={handleBack}
-            className="flex items-center text-sm text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100"
-          >
-            <ChevronLeft size={16} className="mr-1" />
-            Back to Groups
-          </button>
+          <div />
           <button
             onClick={() => handleRemoveGroup(selectedGroup.id)}
             className="text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 text-sm"


### PR DESCRIPTION
- Tools&Memory 노드의 그룹 생성 시 생기는 뒤로가기 (Back to Groups) 기능 제거

Related to: #55 