### PR TITLE
162_노드 색상 변경

### DIFF
--- a/ui/src/components/edges/CustomEdge.tsx
+++ b/ui/src/components/edges/CustomEdge.tsx
@@ -390,7 +390,7 @@ const CustomEdge = ({
           markerHeight="6"
           orient="auto-start-reverse"
         >
-          <path d="M 0 0 L 10 5 L 0 10 z" fill={isDarkMode ? "#60a5fa" : "#3b82f6"} />
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#97A2B6" />
         </marker>
       </defs>
       
@@ -402,7 +402,7 @@ const CustomEdge = ({
           isDragging ? 'stroke-[3px]' : 'stroke-[2px]'
         }`}
         d={inputPath}
-        stroke={isDarkMode ? "#60a5fa" : "#3b82f6"}
+        stroke="#97A2B6"
         strokeDasharray="5,5"
         fill="none"
         style={{ 
@@ -427,7 +427,7 @@ const CustomEdge = ({
         }`}
         d={outputPath}
         markerEnd="url(#arrow)"
-        stroke={isDarkMode ? "#60a5fa" : "#3b82f6"}
+        stroke="#97A2B6"
         strokeDasharray="5,5"
         fill="none"
         style={{ 

--- a/ui/src/components/nodes/CustomNode.tsx
+++ b/ui/src/components/nodes/CustomNode.tsx
@@ -154,20 +154,20 @@ export const CustomNode = memo(({ data, isConnectable, id, type }: NodeProps) =>
       },
       'promptNode': {
         backgroundColor: isDarkMode ? '#1f2937' : '#ffffff',
-        borderColor: '#3b82f6',
-        iconColor: '#3b82f6',
+        borderColor: '#25A18E',
+        iconColor: '#25A18E',
         textColor: isDarkMode ? '#d1d5db' : '#374151'
       },
       'functionNode': {
         backgroundColor: isDarkMode ? '#1f2937' : '#ffffff',
-        borderColor: '#8b5cf6',
-        iconColor: '#8b5cf6',
+        borderColor: '#5B5F97',
+        iconColor: '#5B5F97',
         textColor: isDarkMode ? '#d1d5db' : '#374151'
       },
       'endNode': {
         backgroundColor: isDarkMode ? '#1f2937' : '#ffffff',
-        borderColor: '#ef4444',
-        iconColor: '#ef4444',
+        borderColor: '#10b981',
+        iconColor: '#10b981',
         textColor: isDarkMode ? '#d1d5db' : '#374151'
       },
       'agentNode': {
@@ -208,8 +208,8 @@ export const CustomNode = memo(({ data, isConnectable, id, type }: NodeProps) =>
       },
       'mergeNode': {
         backgroundColor: isDarkMode ? '#1f2937' : '#ffffff',
-        borderColor: '#8b5cf6',
-        iconColor: '#8b5cf6',
+        borderColor: '#FF6B6C',
+        iconColor: '#FF6B6C',
         textColor: isDarkMode ? '#d1d5db' : '#374151'
       },
       'userNode': {

--- a/ui/src/data/nodeCategories.tsx
+++ b/ui/src/data/nodeCategories.tsx
@@ -20,12 +20,12 @@ export interface NodeCategory {
 // 아이콘 색상을 반환하는 함수
 const getIconColor = (nodeType: string, isDarkMode: boolean = false) => {
   const colors: Record<string, { light: string; dark: string }> = {
-    'promptNode': { light: '#3b82f6', dark: '#60a5fa' },
+    'promptNode': { light: '#25A18E', dark: '#25A18E' },
     'agentNode': { light: '#3b82f6', dark: '#60a5fa' },
     'conditionNode': { light: '#f59e0b', dark: '#fbbf24' },
-    'functionNode': { light: '#8b5cf6', dark: '#a78bfa' },
+    'functionNode': { light: '#5B5F97', dark: '#5B5F97' },
     'toolsMemoryNode': { light: '#6b7280', dark: '#9ca3af' },
-    'mergeNode': { light: '#8b5cf6', dark: '#a78bfa' }
+    'mergeNode': { light: '#FF6B6C', dark: '#FF6B6C' }
   };
   
   const color = colors[nodeType];


### PR DESCRIPTION
<img width="2362" height="840" alt="image" src="https://github.com/user-attachments/assets/0822ebc7-33fe-41d8-813c-49ffdc4dfbe0" />
<img width="2330" height="790" alt="image" src="https://github.com/user-attachments/assets/5009a3d4-4841-4c02-a95d-e84e7e929af0" />

- 노드 색상 변경으로 가독성 확보

Related to: #162 