### PR TITLE
153 node inspector 노드별 설명 입력 기능

### DIFF
--- a/ui/src/components/nodes/CustomNode.tsx
+++ b/ui/src/components/nodes/CustomNode.tsx
@@ -4,6 +4,7 @@ import { ChevronRight, X, Play, Loader, Edit2, AlertCircle, Plus, Trash2, Eye } 
 import { useFlowStore } from '../../store/flowStore';
 import { useThemeStore } from '../../store/themeStore';
 import PromptTemplatePopup from './PromptTemplatePopup';
+import { getNodeDescription } from '../../utils/nodeDescriptions';
 
 /**
  * CustomNode 컴포넌트
@@ -51,25 +52,21 @@ export const CustomNode = memo(({ data, isConnectable, id, type }: NodeProps) =>
   // 재생 버튼 활성화 조건: 모든 노드는 source(출력) 연결 기준
   const hasConnection = edges.some(edge => edge.source === id);
 
-  // 노드 설명 텍스트 생성
-  const getNodeDescription = () => {
-    const descriptions: Record<string, string> = {
-      'startNode': 'A start node in the workflow',
-      'promptNode': 'A prompt node for user input and AI responses',
-      'functionNode': 'A function node for executing custom logic',
-      'endNode': 'An end node that terminates the workflow',
-      'agentNode': 'An agent node for AI agent interactions',
-      'conditionNode': 'A condition node for workflow branching',
-      'toolNode': 'A tool node for external tool integration',
-      'toolsMemoryNode': 'A tools and memory management node',
-      'embeddingNode': 'An embedding node for vector operations',
-      'ragNode': 'A RAG node for retrieval-augmented generation',
-      'mergeNode': 'A merge node for combining multiple inputs',
-      'userNode': 'A user interaction node'
-    };
-    
-    return descriptions[type] || 'A workflow node';
+  // 노드 설명 텍스트 생성 (노드 데이터의 description 우선, 없으면 기본값 사용)
+  const getNodeDescriptionText = () => {
+    // 노드 데이터에 description이 있으면 그것을 사용, 없으면 기본값 사용
+    return data.description || getNodeDescription(type);
   };
+
+  // 툴팁용 설명 텍스트 (40자 제한)
+  const getTooltipDescription = () => {
+    const fullDescription = getNodeDescriptionText();
+    if (fullDescription.length <= 40) {
+      return fullDescription;
+    }
+    return fullDescription.substring(0, 40) + '...';
+  };
+
 
   // 노드 더블클릭 핸들러 - 툴팁 토글
   const handleNodeDoubleClick = () => {
@@ -731,8 +728,11 @@ export const CustomNode = memo(({ data, isConnectable, id, type }: NodeProps) =>
                       <h3 className="font-bold text-sm mb-1" style={{ color: nodeStyle.iconColor }}>
                         {data.label}
                       </h3>
-                      <p className="text-xs" style={{ color: nodeStyle.textColor }}>
-                        {getNodeDescription()}
+                      <p 
+                        className="text-xs" 
+                        style={{ color: nodeStyle.textColor }}
+                      >
+                        {getTooltipDescription()}
                       </p>
                     </div>
                     <button

--- a/ui/src/components/nodes/ToolsMemorySettings.tsx
+++ b/ui/src/components/nodes/ToolsMemorySettings.tsx
@@ -177,13 +177,13 @@ const ToolsMemorySettings: React.FC<ToolsMemorySettingsProps> = ({ nodeId }) => 
 
           <div>
             <label className="block text-sm font-medium text-gray-600 dark:text-gray-300 mb-1">
-              Description
+              Tools Description
             </label>
             <textarea
               value={selectedGroup.description}
               onChange={(e) => handleUpdateGroup(selectedGroup.id, { description: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-              placeholder="Enter group description"
+              placeholder="Enter tools description"
               rows={2}
             />
           </div>

--- a/ui/src/components/nodes/nodeTypes.tsx
+++ b/ui/src/components/nodes/nodeTypes.tsx
@@ -11,8 +11,7 @@ const AgentNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Bot size={20} />,
-      nodeType: 'agentNode',
-      description: 'Agent that can execute tools'
+      nodeType: 'agentNode'
     }}
   />
 );
@@ -23,8 +22,7 @@ const ConditionNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Split size={20} />,
-      nodeType: 'conditionNode',
-      description: 'Conditional function to determine which route to take next'
+      nodeType: 'conditionNode'
     }}
   />
 );
@@ -35,8 +33,7 @@ const FunctionNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Database size={20} />,
-      nodeType: 'functionNode',
-      description: 'Data processing and storage node'
+      nodeType: 'functionNode'
     }}
   />
 );
@@ -47,8 +44,7 @@ const StartNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Play size={20} />,
-      nodeType: 'startNode',
-      description: 'Starting point of the workflow'
+      nodeType: 'startNode'
     }}
   />
 );
@@ -59,8 +55,7 @@ const EndNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Square size={20} />,
-      nodeType: 'endNode',
-      description: 'End of workflow'
+      nodeType: 'endNode'
     }}
   />
 );
@@ -71,8 +66,7 @@ const PromptNode = (props: any) => (
     data={{
       ...props.data,
       icon: <MessageSquare size={20} />,
-      nodeType: 'promptNode',
-      description: 'Define a prompt template for LLM interaction'
+      nodeType: 'promptNode'
     }}
   />
 );
@@ -83,8 +77,7 @@ const SystemPromptNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Settings size={20} />,
-      nodeType: 'systemPromptNode',
-      description: 'Define system and user prompts for LLM interaction'
+      nodeType: 'systemPromptNode'
     }}
   />
 );
@@ -95,8 +88,7 @@ const ToolsMemoryNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Group size={20} />,
-      nodeType: 'toolsMemoryNode',
-      description: 'Tools and Memory groups management'
+      nodeType: 'toolsMemoryNode'
     }}
   />
 );
@@ -107,8 +99,7 @@ const EmbeddingNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Database size={20} />,
-      nodeType: 'embeddingNode',
-      description: 'Generate embeddings from text using configured models'
+      nodeType: 'embeddingNode'
     }}
   />
 );
@@ -119,8 +110,7 @@ const RAGNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Database size={20} />,
-      nodeType: 'ragNode',
-      description: 'Retrieval-Augmented Generation using vector store'
+      nodeType: 'ragNode'
     }}
   />
 );
@@ -131,8 +121,7 @@ const MergeNode = (props: any) => (
     data={{
       ...props.data,
       icon: <GitMerge size={20} />,
-      nodeType: 'mergeNode',
-      description: 'Merge inputs from multiple nodes'
+      nodeType: 'mergeNode'
     }}
   />
 );
@@ -143,8 +132,7 @@ const UserNode = (props: any) => (
     data={{
       ...props.data,
       icon: <Database size={20} />,
-      nodeType: 'userNode',
-      description: 'User-defined custom node'
+      nodeType: 'userNode'
     }}
   />
 );

--- a/ui/src/data/nodeCategories.tsx
+++ b/ui/src/data/nodeCategories.tsx
@@ -3,6 +3,7 @@ import {
   Bot, Split, MessageSquare, Settings, Group, GitMerge,
   Database, Cpu
 } from 'lucide-react';
+import { getNodeCategoryDescription } from '../utils/nodeDescriptions';
 
 export interface NodeItem {
   type: string;
@@ -40,7 +41,7 @@ export const nodeCategories: NodeCategory[] = [
       {
         type: 'promptNode',
         label: 'Prompt',
-        description: 'Define a prompt template for LLM interaction',
+        description: getNodeCategoryDescription('promptNode'),
         icon: (className = '', isDarkMode = false) => (
           <MessageSquare size={20} className={className} style={{ color: getIconColor('promptNode', isDarkMode) }} />
         )
@@ -54,7 +55,7 @@ export const nodeCategories: NodeCategory[] = [
       {
         type: 'agentNode',
         label: 'Agent',
-        description: 'Agent that can execute tools',
+        description: getNodeCategoryDescription('agentNode'),
         icon: (className = '', isDarkMode = false) => (
           <Bot size={20} className={className} style={{ color: getIconColor('agentNode', isDarkMode) }} />
         )
@@ -62,7 +63,7 @@ export const nodeCategories: NodeCategory[] = [
       {
         type: 'conditionNode',
         label: 'Condition',
-        description: 'Conditional function to determine which route to take next',
+        description: getNodeCategoryDescription('conditionNode'),
         icon: (className = '', isDarkMode = false) => (
           <Split size={20} className={className} style={{ color: getIconColor('conditionNode', isDarkMode) }} />
         )
@@ -70,7 +71,7 @@ export const nodeCategories: NodeCategory[] = [
       {
         type: 'functionNode',
         label: 'Custom Python Function',
-        description: 'Execute custom Python function',
+        description: getNodeCategoryDescription('functionNode'),
         icon: (className = '', isDarkMode = false) => (
           <Database size={20} className={className} style={{ color: getIconColor('functionNode', isDarkMode) }} />
         )
@@ -78,7 +79,7 @@ export const nodeCategories: NodeCategory[] = [
       {
         type: 'toolsMemoryNode',
         label: 'Tools&Memory',
-        description: 'Tools and Memory groups management',
+        description: getNodeCategoryDescription('toolsMemoryNode'),
         icon: (className = '', isDarkMode = false) => (
           <Group size={20} className={className} style={{ color: getIconColor('toolsMemoryNode', isDarkMode) }} />
         )
@@ -86,7 +87,7 @@ export const nodeCategories: NodeCategory[] = [
       {
         type: 'mergeNode',
         label: 'Merge',
-        description: 'Merge inputs from multiple nodes',
+        description: getNodeCategoryDescription('mergeNode'),
         icon: (className = '', isDarkMode = false) => (
           <GitMerge size={20} className={className} style={{ color: getIconColor('mergeNode', isDarkMode) }} />
         )

--- a/ui/src/utils/nodeDescriptions.ts
+++ b/ui/src/utils/nodeDescriptions.ts
@@ -1,0 +1,48 @@
+/**
+ * 노드 타입별 기본 description을 관리하는 유틸리티
+ * CustomNode 툴팁과 NodeInspector에서 공통으로 사용
+ */
+
+export const getNodeDescription = (nodeType: string): string => {
+  const descriptions: Record<string, string> = {
+    'startNode': 'A start node in the workflow',
+    'promptNode': 'A prompt node for user input and AI responses',
+    'systemPromptNode': 'A system prompt node for defining system behavior',
+    'functionNode': 'A function node for executing custom logic',
+    'endNode': 'An end node that terminates the workflow',
+    'agentNode': 'An agent node for AI agent interactions',
+    'conditionNode': 'A condition node for workflow branching',
+    'toolNode': 'A tool node for external tool integration',
+    'toolsMemoryNode': 'A tools and memory management node',
+    'embeddingNode': 'An embedding node for vector operations',
+    'ragNode': 'A RAG node for retrieval-augmented generation',
+    'mergeNode': 'A merge node for combining multiple inputs',
+    'userNode': 'A user interaction node',
+    'groupsNode': 'A groups node for managing collections'
+  };
+  
+  return descriptions[nodeType] || 'A workflow node';
+};
+
+/**
+ * nodeCategories에서 사용할 description을 반환
+ * CustomNode의 description과 동일하게 유지
+ */
+export const getNodeCategoryDescription = (nodeType: string): string => {
+  const categoryDescriptions: Record<string, string> = {
+    'promptNode': 'A prompt node for user input and AI responses',
+    'systemPromptNode': 'A system prompt node for defining system behavior',
+    'agentNode': 'An agent node for AI agent interactions',
+    'conditionNode': 'A condition node for workflow branching',
+    'functionNode': 'A function node for executing custom logic',
+    'toolsMemoryNode': 'A tools and memory management node',
+    'mergeNode': 'A merge node for combining multiple inputs',
+    'embeddingNode': 'An embedding node for vector operations',
+    'ragNode': 'A RAG node for retrieval-augmented generation',
+    'userNode': 'A user interaction node',
+    'startNode': 'A start node in the workflow',
+    'endNode': 'An end node that terminates the workflow'
+  };
+  
+  return categoryDescriptions[nodeType] || 'A workflow node';
+};


### PR DESCRIPTION
파일 누락으로 다시 PR 요청

1.ToolTIp 글자수 40자 표시
<img width="1267" height="533" alt="image" src="https://github.com/user-attachments/assets/2572cf8b-0288-40cc-81ff-88b11c2fe40e" />
2. NodeInspector Description 작성 기능 추가 구현
<img width="379" height="279" alt="image" src="https://github.com/user-attachments/assets/10faff73-4a89-4db5-bdaa-b92475c35cdb" />
 기본값 적용 에디터 조정 기능 가능
3. Tools 노드의 경우 기존 Description이 있어서, 중복 되는 표현으로 Tools Description으로 명칭 변경
<img width="388" height="715" alt="image" src="https://github.com/user-attachments/assets/4cc140ac-9c70-4339-a72c-22c3498b6091" />

Releated to https://github.com/SurvivorsStudio/langstar/issues/153