### PR TITLE
151_footer 하단 정보 UI 변경

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/src/assets/common/home_logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LangStar - AI Workflow Builder</title>
   </head>

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -10,18 +10,29 @@ const Footer: React.FC = () => {
         <div className="flex items-center space-x-3">
           <button
             onClick={toggleDarkMode}
-            className="group relative p-3 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 transition-all duration-200 ease-in-out transform hover:scale-105 active:scale-95 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
-            aria-label="테마 전환"
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-800 ${
+              isDarkMode ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
+            }`}
+            role="switch"
+            aria-checked={isDarkMode}
+            aria-label="다크모드 전환"
           >
-            {isDarkMode ? (
-              <svg className="w-5 h-5 text-yellow-500 group-hover:text-yellow-400 transition-colors duration-200" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z"/>
-              </svg>
-            ) : (
-              <svg className="w-5 h-5 text-blue-500 group-hover:text-blue-400 transition-colors duration-200" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z"/>
-              </svg>
-            )}
+            <span className="sr-only">다크모드 전환</span>
+            <span
+              className={`${
+                isDarkMode ? 'translate-x-6' : 'translate-x-1'
+              } inline-flex h-4 w-4 transform items-center justify-center rounded-full bg-white shadow-lg transition-transform duration-200 ease-in-out`}
+            >
+              {isDarkMode ? (
+                <svg className="h-3 w-3 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z"/>
+                </svg>
+              ) : (
+                <svg className="h-3 w-3 text-yellow-500" fill="currentColor" viewBox="0 0 24 24">
+                  <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z"/>
+                </svg>
+              )}
+            </span>
           </button>
         </div>
       </div>

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -6,24 +6,8 @@ const Footer: React.FC = () => {
 
   return (
     <footer className="bg-gray-100 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
-      <div className="px-4 py-3 flex justify-between items-center text-sm text-gray-600 dark:text-gray-400">
-        <div className="flex items-center space-x-4">
-          <span>© 2024 워크플로우 에디터</span>
-          <a 
-            href="https://github.com" 
-            target="_blank" 
-            rel="noopener noreferrer"
-            className="flex items-center space-x-1 hover:text-gray-800 dark:hover:text-gray-200 transition-colors"
-          >
-            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-            </svg>
-            <span>GitHub</span>
-          </a>
-        </div>
-        
+      <div className="px-4 py-3 flex justify-end items-center text-sm text-gray-600 dark:text-gray-400">
         <div className="flex items-center space-x-3">
-          <span className="text-sm font-medium">테마</span>
           <button
             onClick={toggleDarkMode}
             className="group relative p-3 rounded-lg bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 active:bg-gray-400 dark:active:bg-gray-500 transition-all duration-200 ease-in-out transform hover:scale-105 active:scale-95 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -5,35 +5,53 @@ const Footer: React.FC = () => {
   const { isDarkMode, toggleDarkMode } = useThemeStore();
 
   return (
-    <footer className="bg-gray-100 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
-      <div className="px-4 py-3 flex justify-end items-center text-sm text-gray-600 dark:text-gray-400">
+    <footer className="relative bg-gradient-to-r from-slate-50 via-gray-50 to-slate-100 dark:from-gray-900 dark:via-slate-900 dark:to-gray-900 border-t border-gray-200/50 dark:border-gray-700/50 shadow-lg backdrop-blur-sm">
+      {/* 상단 그라데이션 라인 */}
+      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/30 to-transparent"></div>
+      
+      <div className="px-6 py-2 flex justify-between items-center text-sm">
         <div className="flex items-center space-x-3">
-          <button
-            onClick={toggleDarkMode}
-            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-800 ${
-              isDarkMode ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
-            }`}
-            role="switch"
-            aria-checked={isDarkMode}
-            aria-label="다크모드 전환"
-          >
-            <span className="sr-only">다크모드 전환</span>
-            <span
-              className={`${
-                isDarkMode ? 'translate-x-6' : 'translate-x-1'
-              } inline-flex h-4 w-4 transform items-center justify-center rounded-full bg-white shadow-lg transition-transform duration-200 ease-in-out`}
-            >
-              {isDarkMode ? (
-                <svg className="h-3 w-3 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z"/>
-                </svg>
-              ) : (
-                <svg className="h-3 w-3 text-yellow-500" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z"/>
-                </svg>
-              )}
+          {/* 브랜드 로고 영역 */}
+          <div className="flex items-center">
+            <span className="text-sm text-gray-600 dark:text-gray-400 font-medium">
+              © 2025 SurvivorsStudio All rights reserved.
             </span>
-          </button>
+          </div>
+        </div>
+        
+        <div className="flex items-center space-x-4">
+          {/* 테마 토글 스위치 */}
+          <div className="flex items-center space-x-2">
+            <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">Theme</span>
+            <button
+              onClick={toggleDarkMode}
+              className={`relative inline-flex h-7 w-12 items-center rounded-full transition-all duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-gray-900 shadow-lg hover:shadow-xl ${
+                isDarkMode 
+                  ? 'bg-gradient-to-r from-blue-600 to-purple-600 shadow-blue-500/25' 
+                  : 'bg-gradient-to-r from-yellow-400 to-orange-500 shadow-yellow-500/25'
+              }`}
+              role="switch"
+              aria-checked={isDarkMode}
+              aria-label="다크모드 전환"
+            >
+              <span className="sr-only">다크모드 전환</span>
+              <span
+                className={`${
+                  isDarkMode ? 'translate-x-6' : 'translate-x-1'
+                } inline-flex h-5 w-5 transform items-center justify-center rounded-full bg-white shadow-lg transition-all duration-300 ease-in-out hover:scale-110`}
+              >
+                {isDarkMode ? (
+                  <svg className="h-3 w-3 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z"/>
+                  </svg>
+                ) : (
+                  <svg className="h-3 w-3 text-yellow-500" fill="currentColor" viewBox="0 0 24 24">
+                    <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z"/>
+                  </svg>
+                )}
+              </span>
+            </button>
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
1. Footer 문구 변경
<img width="573" height="71" alt="image" src="https://github.com/user-attachments/assets/ac685a00-b942-47f3-953e-298f45c5f849" />

2. Footer 사이즈 축소
<img width="2559" height="1348" alt="image" src="https://github.com/user-attachments/assets/51106ac3-14a9-4d8e-bdb1-12515cd6c4b0" />

3.   Footer 테마 문구 및 버튼 디자인 수정 (Toggle Switch)
<img width="149" height="50" alt="image" src="https://github.com/user-attachments/assets/a678c7e6-2b9f-4ce2-ac76-21f5d3b2b747" />
<img width="144" height="46" alt="image" src="https://github.com/user-attachments/assets/021967b6-b5ba-4178-bc42-9af6f27f6601" />

4. Favicon Icon 변경 작업 진행 (home_logo.png 와 동일한 아이콘으로 구성)
<img width="248" height="47" alt="image" src="https://github.com/user-attachments/assets/6c8c8bde-59b9-4b02-98dd-ca31a8cb0fd1" />


Releated to: #151 
