### PR TITLE
165 노드사이 연결하는 엣지흐름 가시성증가

### DIFF
--- a/ui/src/components/ExecutionStatusIndicator.tsx
+++ b/ui/src/components/ExecutionStatusIndicator.tsx
@@ -1,0 +1,175 @@
+import React, { useState, useEffect } from 'react';
+import { CheckCircle, Clock, Play, ArrowRight } from 'lucide-react';
+import { useNodeExecutionEvents } from '../hooks/useNodeExecutionEvents';
+
+interface ExecutionStep {
+  fromNodeId: string;
+  toNodeId: string;
+  fromLabel: string;
+  toLabel: string;
+  status: 'pending' | 'executing' | 'completed' | 'error';
+  timestamp?: Date;
+}
+
+/**
+ * 노드 실행 상태를 시각적으로 표시하는 컴포넌트
+ */
+const ExecutionStatusIndicator: React.FC = () => {
+  const [executionSteps, setExecutionSteps] = useState<ExecutionStep[]>([]);
+  const [isGlobalExecution, setIsGlobalExecution] = useState(false);
+
+  const { executingNodes, isAnyNodeExecuting } = useNodeExecutionEvents((nodeId, eventType) => {
+    if (eventType === 'start') {
+      handleNodeExecutionStart(nodeId);
+    } else {
+      handleNodeExecutionEnd(nodeId);
+    }
+  });
+
+  const handleNodeExecutionStart = (nodeId: string) => {
+    console.log(`🎬 노드 실행 시작: ${nodeId}`);
+    
+    // 개별 노드 실행인지 전체 실행인지 판단
+    if (executingNodes.length <= 1) {
+      // 개별 실행: 현재 노드와 연결된 다음 노드들 표시
+      showIndividualExecution(nodeId);
+    } else {
+      // 전체 실행: 워크플로우 단계별 표시
+      setIsGlobalExecution(true);
+    }
+  };
+
+  const handleNodeExecutionEnd = (nodeId: string) => {
+    console.log(`🏁 노드 실행 완료: ${nodeId}`);
+    
+    // 해당 노드의 실행 상태를 완료로 업데이트
+    setExecutionSteps(prev => 
+      prev.map(step => 
+        step.fromNodeId === nodeId 
+          ? { ...step, status: 'completed', timestamp: new Date() }
+          : step
+      )
+    );
+
+    // 3초 후 개별 실행 표시 제거
+    if (!isGlobalExecution) {
+      setTimeout(() => {
+        setExecutionSteps(prev => prev.filter(step => step.fromNodeId !== nodeId));
+      }, 3000);
+    }
+  };
+
+  const showIndividualExecution = (nodeId: string) => {
+    // 여기서 실제 노드 데이터를 가져와서 연결된 노드들 찾기
+    // 임시 예시 데이터
+    const mockStep: ExecutionStep = {
+      fromNodeId: nodeId,
+      toNodeId: 'next-node',
+      fromLabel: getNodeLabel(nodeId),
+      toLabel: 'Next Node',
+      status: 'executing',
+      timestamp: new Date()
+    };
+
+    setExecutionSteps(prev => [...prev, mockStep]);
+  };
+
+  const getNodeLabel = (nodeId: string) => {
+    // 실제 구현에서는 flowStore에서 노드 정보 가져오기
+    const nodeLabels: { [key: string]: string } = {
+      'start': 'Start',
+      'prompt': 'Prompt',
+      'agent': 'Agent'
+    };
+    return nodeLabels[nodeId] || nodeId;
+  };
+
+  if (!isAnyNodeExecuting && executionSteps.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="fixed top-4 right-4 bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 z-50">
+      <div className="space-y-3">
+        {/* 전체 실행 상태 */}
+        {isGlobalExecution && (
+          <div className="flex items-center space-x-2">
+            <div className="animate-spin w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full"></div>
+            <span className="text-sm font-medium text-blue-600 dark:text-blue-400">
+              워크플로우 실행 중...
+            </span>
+          </div>
+        )}
+
+        {/* 개별 실행 단계들 */}
+        {executionSteps.map((step, index) => (
+          <IndividualExecutionStep key={`${step.fromNodeId}-${index}`} step={step} />
+        ))}
+
+        {/* 현재 실행 중인 노드들 */}
+        {executingNodes.length > 0 && (
+          <div className="border-t pt-2">
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">실행 중:</p>
+            {executingNodes.map(node => (
+              <div key={node.id} className="flex items-center space-x-2 text-sm">
+                <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse"></div>
+                <span className="text-green-600 dark:text-green-400">{node.label}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/**
+ * 개별 실행 단계를 표시하는 컴포넌트
+ */
+const IndividualExecutionStep: React.FC<{ step: ExecutionStep }> = ({ step }) => {
+  const getStatusIcon = () => {
+    switch (step.status) {
+      case 'executing':
+        return <div className="animate-spin w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full" />;
+      case 'completed':
+        return <CheckCircle className="w-4 h-4 text-green-500" />;
+      case 'error':
+        return <div className="w-4 h-4 bg-red-500 rounded-full" />;
+      default:
+        return <Clock className="w-4 h-4 text-gray-400" />;
+    }
+  };
+
+  const getStatusColor = () => {
+    switch (step.status) {
+      case 'executing':
+        return 'text-blue-600 dark:text-blue-400';
+      case 'completed':
+        return 'text-green-600 dark:text-green-400';
+      case 'error':
+        return 'text-red-600 dark:text-red-400';
+      default:
+        return 'text-gray-600 dark:text-gray-400';
+    }
+  };
+
+  return (
+    <div className={`flex items-center space-x-2 p-2 rounded-md bg-gray-50 dark:bg-gray-700 ${
+      step.status === 'completed' ? 'bg-green-50 dark:bg-green-900/20' : ''
+    }`}>
+      {getStatusIcon()}
+      <div className="flex items-center space-x-1 text-sm">
+        <span className={getStatusColor()}>{step.fromLabel}</span>
+        <ArrowRight className="w-3 h-3 text-gray-400" />
+        <span className={getStatusColor()}>{step.toLabel}</span>
+      </div>
+      {step.status === 'completed' && step.timestamp && (
+        <span className="text-xs text-gray-500">
+          {step.timestamp.toLocaleTimeString()}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default ExecutionStatusIndicator;

--- a/ui/src/components/ExecutionToast.tsx
+++ b/ui/src/components/ExecutionToast.tsx
@@ -1,0 +1,186 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { CheckCircle, AlertCircle, Clock, X } from 'lucide-react';
+import { useNodeExecutionEvents } from '../hooks/useNodeExecutionEvents';
+import { useFlowStore } from '../store/flowStore';
+
+interface ToastMessage {
+  id: string;
+  type: 'success' | 'error' | 'info';
+  title: string;
+  message: string;
+  duration?: number;
+  timestamp: Date;
+}
+
+/**
+ * 노드 실행 완료 시 토스트 알림을 표시하는 컴포넌트
+ */
+const ExecutionToast: React.FC = () => {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+  const nodes = useFlowStore(state => state.nodes);
+
+  // 노드 실행 완료 이벤트 감지
+  useEffect(() => {
+    const handleToastEvent = (event: CustomEvent) => {
+      const { nodeId, success = true, nodeName, failedNodeName } = event.detail;
+      
+      // 실행 시점에 전달받은 노드 이름 사용 (가장 정확함)
+      const nodeLabel = nodeName || 'Node';
+      
+      // 워크플로우 실패 시 실패한 노드 정보 포함
+      let message;
+      if (success) {
+        message = `${nodeLabel} node has been executed successfully.`;
+      } else {
+        if (nodeId === 'workflow' && failedNodeName) {
+          message = `Workflow failed at ${failedNodeName} node. Please check the configuration.`;
+        } else {
+          message = `${nodeLabel} node execution failed. Please check the configuration.`;
+        }
+      }
+      
+      const toast: ToastMessage = {
+        id: `${nodeId}-${Date.now()}`,
+        type: success ? 'success' : 'error',
+        title: success ? 'Node Execution Completed' : 'Node Execution Failed',
+        message,
+        duration: 4000,
+        timestamp: new Date()
+      };
+
+      setToasts(prev => [...prev, toast]);
+
+      // 자동 제거
+      setTimeout(() => {
+        setToasts(prev => prev.filter(t => t.id !== toast.id));
+      }, 4000);
+    };
+
+    window.addEventListener('nodeExecutionCompleted', handleToastEvent as EventListener);
+    
+    return () => {
+      window.removeEventListener('nodeExecutionCompleted', handleToastEvent as EventListener);
+    };
+  }, []); // 빈 의존성 배열
+
+  const showCompletionToast = useCallback((nodeId: string) => {
+    const node = nodes.find(n => n.id === nodeId);
+    const nodeLabel = node?.data?.label || node?.type || `Node ${nodeId}`;
+    
+    const toast: ToastMessage = {
+      id: `${nodeId}-${Date.now()}`,
+      type: 'success',
+      title: '노드 실행 완료',
+      message: `${nodeLabel} 노드가 성공적으로 실행되었습니다.`,
+      duration: 4000,
+      timestamp: new Date()
+    };
+
+    console.log('🍞 Toast: Adding toast:', toast);
+    setToasts(prev => {
+      const newToasts = [...prev, toast];
+      console.log('🍞 Toast: Current toasts:', newToasts);
+      return newToasts;
+    });
+
+    // 자동 제거
+    setTimeout(() => {
+      removeToast(toast.id);
+    }, toast.duration);
+  }, [nodes]);
+
+  const removeToast = (id: string) => {
+    setToasts(prev => prev.filter(toast => toast.id !== id));
+  };
+
+
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 space-y-2">
+      {toasts.map((toast) => (
+        <ToastItem 
+          key={toast.id} 
+          toast={toast} 
+          onRemove={() => removeToast(toast.id)} 
+        />
+      ))}
+    </div>
+  );
+};
+
+/**
+ * 개별 토스트 아이템 컴포넌트
+ */
+const ToastItem: React.FC<{ 
+  toast: ToastMessage; 
+  onRemove: () => void; 
+}> = ({ toast, onRemove }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    // 등장 애니메이션
+    setTimeout(() => setIsVisible(true), 100);
+  }, []);
+
+  const handleRemove = () => {
+    setIsVisible(false);
+    setTimeout(onRemove, 300); // 애니메이션 후 제거
+  };
+
+  const getIcon = () => {
+    switch (toast.type) {
+      case 'success':
+        return <CheckCircle className="w-5 h-5 text-green-500" />;
+      case 'error':
+        return <AlertCircle className="w-5 h-5 text-red-500" />;
+      default:
+        return <Clock className="w-5 h-5 text-blue-500" />;
+    }
+  };
+
+  const getBorderColor = () => {
+    switch (toast.type) {
+      case 'success':
+        return 'border-l-green-500';
+      case 'error':
+        return 'border-l-red-500';
+      default:
+        return 'border-l-blue-500';
+    }
+  };
+
+  return (
+    <div className={`
+      transform transition-all duration-300 ease-in-out
+      ${isVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'}
+      bg-white dark:bg-gray-800 border-l-4 ${getBorderColor()} 
+      rounded-lg shadow-lg p-4 min-w-[300px] max-w-[400px]
+    `}>
+      <div className="flex items-start space-x-3">
+        {getIcon()}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+            {toast.title}
+          </p>
+          <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
+            {toast.message}
+          </p>
+          <p className="text-xs text-gray-400 mt-1">
+            {toast.timestamp.toLocaleTimeString()}
+          </p>
+        </div>
+        <button
+          onClick={handleRemove}
+          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ExecutionToast;

--- a/ui/src/components/FlowBuilder.tsx
+++ b/ui/src/components/FlowBuilder.tsx
@@ -17,6 +17,8 @@ import { useFlowStore } from '../store/flowStore';
 import { useThemeStore } from '../store/themeStore';
 import NodeSidebar from './NodeSidebar';
 import NodeInspector from './NodeInspector';
+import ExecutionStatusIndicator from './ExecutionStatusIndicator';
+import ExecutionToast from './ExecutionToast';
 import { nodeTypes } from './nodes/nodeTypes';
 import CustomEdge, { handleEdgeDelete } from './edges/CustomEdge';
 import { PlusCircle, Trash2 } from 'lucide-react';
@@ -405,7 +407,7 @@ const FlowBuilder: React.FC = () => {
           {showTrashZone && (
             <div
               id="trash-zone"
-              className={`fixed bottom-32 left-1/2 transform -translate-x-1/2 z-50 p-4 rounded-full shadow-lg transition-all duration-300 border-4 ${
+              className={`fixed bottom-16 left-1/2 transform -translate-x-1/2 z-50 p-4 rounded-full shadow-lg transition-all duration-300 border-4 ${
                 isOverTrashZone 
                   ? 'bg-red-500/40 text-red-600 scale-125 border-red-600 shadow-2xl' 
                   : 'bg-gray-500/40 text-gray-700 dark:text-gray-200 border-gray-400/40 dark:border-gray-500/40 hover:scale-110 hover:bg-gray-500/50 hover:text-gray-800 dark:hover:text-gray-100'
@@ -463,6 +465,10 @@ const FlowBuilder: React.FC = () => {
           }}
         />
       )}
+      
+      {/* 실행 상태 표시 컴포넌트들 */}
+      <ExecutionStatusIndicator />
+      <ExecutionToast />
     </div>
   );
 };

--- a/ui/src/components/NodeExecutionMonitor.tsx
+++ b/ui/src/components/NodeExecutionMonitor.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { useNodeExecutionEvents, useNodeExecutionStatus } from '../hooks/useNodeExecutionEvents';
+
+/**
+ * 노드 실행 모니터링 컴포넌트 예시
+ */
+const NodeExecutionMonitor: React.FC = () => {
+  // 모든 노드의 실행 이벤트 감지
+  const { executingNodes, isAnyNodeExecuting } = useNodeExecutionEvents((nodeId, eventType) => {
+    if (eventType === 'start') {
+      console.log(`🎬 노드 ${nodeId} 실행 시작!`);
+      // 여기서 원하는 작업 수행 (예: 애니메이션 시작)
+    } else {
+      console.log(`🏁 노드 ${nodeId} 실행 완료!`);
+      // 여기서 원하는 작업 수행 (예: 애니메이션 정지)
+    }
+  });
+
+  // 특정 노드의 실행 상태 감지 (예시)
+  const { isExecuting: isStartNodeExecuting } = useNodeExecutionStatus('start', (isExecuting, nodeId) => {
+    console.log(`Start 노드 실행 상태: ${isExecuting}`);
+  });
+
+  return (
+    <div className="fixed top-4 right-4 bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg border">
+      <h3 className="text-lg font-semibold mb-2">노드 실행 모니터</h3>
+      
+      <div className="space-y-2">
+        <div className={`text-sm ${isAnyNodeExecuting ? 'text-green-600' : 'text-gray-500'}`}>
+          {isAnyNodeExecuting ? '🟢 실행 중' : '⚪ 대기 중'}
+        </div>
+        
+        {executingNodes.length > 0 && (
+          <div>
+            <p className="text-sm font-medium">실행 중인 노드들:</p>
+            <ul className="text-xs space-y-1">
+              {executingNodes.map(node => (
+                <li key={node.id} className="text-blue-600">
+                  • {node.label} ({node.type})
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NodeExecutionMonitor;

--- a/ui/src/components/NodeInspector.tsx
+++ b/ui/src/components/NodeInspector.tsx
@@ -666,24 +666,44 @@ const NodeInspector: React.FC<NodeInspectorProps> = ({ nodeId, selectedEdge, onC
             ) : (
               <div className="space-y-3">
                                  {/* 선택된 데이터 표시 */}
-                 {selectedEdgeInfo && (
+                 {selectedEdgeInfo && (() => {
+                   // 에러 상태 확인
+                   const hasError = mergedInputData && typeof mergedInputData === 'object' && mergedInputData.error;
+                   
+                   return (
                    <div 
-                     className={`border rounded-lg p-3 cursor-pointer transition-colors bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-700 hover:bg-green-100 dark:hover:bg-green-900/30 ${manuallySelectedEdgeId === selectedEdgeInfo.edgeId ? 'border-2 border-blue-500' : ''}`}
+                     className={`border rounded-lg p-3 cursor-pointer transition-colors ${
+                       hasError 
+                         ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-700 hover:bg-red-100 dark:hover:bg-red-900/30'
+                         : 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-700 hover:bg-green-100 dark:hover:bg-green-900/30'
+                     } ${manuallySelectedEdgeId === selectedEdgeInfo.edgeId ? 'border-2 border-blue-500' : ''}`}
                      onClick={() => handleInputDataClick(selectedEdgeInfo.edgeId, selectedEdgeInfo.sourceNodeId, mergedInputData)}
                      title="Click to execute with this input"
                    >
                      <div className="flex items-center justify-between mb-2">
-                       <span className="text-xs font-medium text-green-700 dark:text-green-300">
-                         ✅ Selected Input (Latest)
+                       <span className={`text-xs font-medium ${
+                         hasError 
+                           ? 'text-red-700 dark:text-red-300' 
+                           : 'text-green-700 dark:text-green-300'
+                       }`}>
+                         {hasError ? '❌ Selected Input (Error)' : '✅ Selected Input (Latest)'}
                        </span>
                        <div className="flex items-center space-x-2">
-                         <span className="text-xs text-green-600 dark:text-green-400">
+                         <span className={`text-xs ${
+                           hasError 
+                             ? 'text-red-600 dark:text-red-400' 
+                             : 'text-green-600 dark:text-green-400'
+                         }`}>
                            {selectedEdgeInfo.timestamp && selectedEdgeInfo.timestamp > 0 
                              ? new Date(selectedEdgeInfo.timestamp).toLocaleTimeString()
                              : 'Not executed yet'
                            }
                          </span>
-                         <Play className="w-3 h-3 text-green-600 dark:text-green-400" />
+                         <Play className={`w-3 h-3 ${
+                           hasError 
+                             ? 'text-red-600 dark:text-red-400' 
+                             : 'text-green-600 dark:text-green-400'
+                         }`} />
                        </div>
                      </div>
                      
@@ -695,7 +715,8 @@ const NodeInspector: React.FC<NodeInspectorProps> = ({ nodeId, selectedEdge, onC
                        </div>
                      </div>
                    </div>
-                 )}
+                   );
+                 })()}
                 
                 {/* 다른 input data들 표시 */}
                 {incomingEdges.length > 1 && (

--- a/ui/src/components/WorkflowProgress.tsx
+++ b/ui/src/components/WorkflowProgress.tsx
@@ -1,0 +1,180 @@
+import React, { useState, useEffect } from 'react';
+import { Play, CheckCircle, Clock, AlertCircle } from 'lucide-react';
+import { useNodeExecutionEvents } from '../hooks/useNodeExecutionEvents';
+import { useFlowStore } from '../store/flowStore';
+
+interface WorkflowStep {
+  nodeId: string;
+  label: string;
+  type: string;
+  status: 'pending' | 'executing' | 'completed' | 'error';
+  order: number;
+}
+
+/**
+ * 전체 워크플로우 실행 진행률을 표시하는 컴포넌트
+ */
+const WorkflowProgress: React.FC = () => {
+  const [workflowSteps, setWorkflowSteps] = useState<WorkflowStep[]>([]);
+  const [isVisible, setIsVisible] = useState(false);
+  const nodes = useFlowStore(state => state.nodes);
+  const edges = useFlowStore(state => state.edges);
+
+  const { executingNodes, isAnyNodeExecuting } = useNodeExecutionEvents((nodeId, eventType) => {
+    if (eventType === 'start') {
+      updateStepStatus(nodeId, 'executing');
+    } else {
+      updateStepStatus(nodeId, 'completed');
+    }
+  });
+
+  // 워크플로우 단계 순서 계산
+  useEffect(() => {
+    if (isAnyNodeExecuting && executingNodes.length > 1) {
+      // 전체 실행 감지
+      const steps = calculateWorkflowSteps();
+      setWorkflowSteps(steps);
+      setIsVisible(true);
+    } else if (!isAnyNodeExecuting) {
+      // 실행 완료 후 3초 뒤 숨김
+      setTimeout(() => {
+        setIsVisible(false);
+        setWorkflowSteps([]);
+      }, 3000);
+    }
+  }, [isAnyNodeExecuting, executingNodes, nodes, edges]);
+
+  const calculateWorkflowSteps = (): WorkflowStep[] => {
+    // 실제로는 노드 그래프를 분석하여 실행 순서 계산
+    // 여기서는 간단한 예시
+    const startNode = nodes.find(n => n.type === 'startNode');
+    if (!startNode) return [];
+
+    const steps: WorkflowStep[] = [];
+    const visited = new Set<string>();
+    let order = 0;
+
+    const traverseGraph = (nodeId: string) => {
+      if (visited.has(nodeId)) return;
+      visited.add(nodeId);
+
+      const node = nodes.find(n => n.id === nodeId);
+      if (!node) return;
+
+      steps.push({
+        nodeId,
+        label: node.data?.label || getDefaultLabel(node.type),
+        type: node.type,
+        status: 'pending',
+        order: order++
+      });
+
+      // 다음 노드들 찾기
+      const outgoingEdges = edges.filter(e => e.source === nodeId);
+      outgoingEdges.forEach(edge => {
+        traverseGraph(edge.target);
+      });
+    };
+
+    traverseGraph(startNode.id);
+    return steps;
+  };
+
+  const updateStepStatus = (nodeId: string, status: WorkflowStep['status']) => {
+    setWorkflowSteps(prev => 
+      prev.map(step => 
+        step.nodeId === nodeId ? { ...step, status } : step
+      )
+    );
+  };
+
+  const getDefaultLabel = (nodeType: string) => {
+    const labels: { [key: string]: string } = {
+      'startNode': 'Start',
+      'promptNode': 'Prompt',
+      'agentNode': 'Agent',
+      'endNode': 'End'
+    };
+    return labels[nodeType] || nodeType;
+  };
+
+  const getStepIcon = (status: WorkflowStep['status']) => {
+    switch (status) {
+      case 'executing':
+        return <div className="animate-spin w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full" />;
+      case 'completed':
+        return <CheckCircle className="w-4 h-4 text-green-500" />;
+      case 'error':
+        return <AlertCircle className="w-4 h-4 text-red-500" />;
+      default:
+        return <Clock className="w-4 h-4 text-gray-400" />;
+    }
+  };
+
+  const completedSteps = workflowSteps.filter(step => step.status === 'completed').length;
+  const totalSteps = workflowSteps.length;
+  const progressPercentage = totalSteps > 0 ? (completedSteps / totalSteps) * 100 : 0;
+
+  if (!isVisible || workflowSteps.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 p-6 rounded-lg shadow-2xl border border-gray-200 dark:border-gray-700 z-50 min-w-[400px]">
+      {/* 헤더 */}
+      <div className="flex items-center space-x-2 mb-4">
+        <Play className="w-5 h-5 text-blue-500" />
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          워크플로우 실행 중
+        </h3>
+      </div>
+
+      {/* 진행률 바 */}
+      <div className="mb-4">
+        <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400 mb-2">
+          <span>{completedSteps}/{totalSteps} 단계 완료</span>
+          <span>{Math.round(progressPercentage)}%</span>
+        </div>
+        <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+          <div 
+            className="bg-blue-500 h-2 rounded-full transition-all duration-500 ease-out"
+            style={{ width: `${progressPercentage}%` }}
+          />
+        </div>
+      </div>
+
+      {/* 단계별 상태 */}
+      <div className="space-y-2 max-h-60 overflow-y-auto">
+        {workflowSteps.map((step, index) => (
+          <div 
+            key={step.nodeId}
+            className={`flex items-center space-x-3 p-2 rounded-md ${
+              step.status === 'executing' ? 'bg-blue-50 dark:bg-blue-900/20' :
+              step.status === 'completed' ? 'bg-green-50 dark:bg-green-900/20' :
+              'bg-gray-50 dark:bg-gray-700'
+            }`}
+          >
+            <div className="flex items-center justify-center w-6 h-6 rounded-full bg-gray-200 dark:bg-gray-600 text-xs font-medium">
+              {index + 1}
+            </div>
+            {getStepIcon(step.status)}
+            <div className="flex-1">
+              <span className={`text-sm font-medium ${
+                step.status === 'executing' ? 'text-blue-600 dark:text-blue-400' :
+                step.status === 'completed' ? 'text-green-600 dark:text-green-400' :
+                'text-gray-600 dark:text-gray-400'
+              }`}>
+                {step.label}
+              </span>
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                {step.type}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default WorkflowProgress;

--- a/ui/src/components/edges/CustomEdge.tsx
+++ b/ui/src/components/edges/CustomEdge.tsx
@@ -42,6 +42,7 @@ const CustomEdge = ({
 
   const [lastMousePosition, setLastMousePosition] = useState<{ x: number; y: number } | null>(null);
   const [dragStartTimeout, setDragStartTimeout] = useState<NodeJS.Timeout | null>(null);
+  const [trashZoneRect, setTrashZoneRect] = useState<DOMRect | null>(null);
 
   // Calculate the center point between source and target
   const centerX = (sourceX + targetX) / 2;
@@ -337,6 +338,20 @@ const CustomEdge = ({
       setEdgeNodePosition(coordinates); // 초기 위치 설정
     }
     
+    // 휴지통 표시를 위한 이벤트 발생
+    window.dispatchEvent(new CustomEvent('edge-drag-start', { detail: { edgeId: id } }));
+    
+    // 휴지통 위치 저장 (50ms 후 휴지통이 나타나면 저장)
+    setTimeout(() => {
+      const trashZone = document.getElementById('trash-zone');
+      if (trashZone) {
+        const rect = trashZone.getBoundingClientRect();
+        setTrashZoneRect(rect);
+      } else {
+        setTrashZoneRect(null);
+      }
+    }, 50);
+    
     // 150ms 후에 드래그 시작 (클릭과 구분)
     const timeout = setTimeout(() => {
       setIsDragging(true);
@@ -357,10 +372,36 @@ const CustomEdge = ({
         }
       };
 
-      const handleMouseUp = () => {
+      const handleMouseUp = (e: MouseEvent) => {
         setIsDragging(false);
 
-        // 마지막 마우스 위치를 엣지 노드 위치로 저장 (이미 실시간으로 업데이트됨)
+        // 저장된 휴지통 위치로 확인
+        const checkTrashZone = () => {
+          if (trashZoneRect) {
+            // 휴지통 영역을 조금 더 크게 계산 (여백 20px 추가)
+            const margin = 20;
+            const isOverTrash = e.clientX >= (trashZoneRect.left - margin) && 
+                              e.clientX <= (trashZoneRect.right + margin) && 
+                              e.clientY >= (trashZoneRect.top - margin) && 
+                              e.clientY <= (trashZoneRect.bottom + margin);
+            return isOverTrash;
+          }
+          return false;
+        };
+
+        const isOverTrashZone = checkTrashZone();
+
+        // 휴지통 영역 정보와 함께 이벤트 발생
+        window.dispatchEvent(new CustomEvent('edge-drag-end', { 
+          detail: { 
+            edgeId: id,
+            mouseX: e.clientX,
+            mouseY: e.clientY,
+            isOverTrashZone
+          } 
+        }));
+        
+        // 마지막 마우스 위치를 엣지 노드 위치로 저장 (휴지통에 드롭되지 않은 경우)
         if (lastMousePosition) {
           updateEdgeData(id, { edgeNodePosition: lastMousePosition });
         }

--- a/ui/src/hooks/useNodeExecutionEvents.ts
+++ b/ui/src/hooks/useNodeExecutionEvents.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from 'react';
+import { useFlowStore } from '../store/flowStore';
+
+type NodeExecutionEventHandler = (nodeId: string, eventType: 'start' | 'end') => void;
+
+/**
+ * 노드 실행 이벤트를 감지하는 커스텀 훅
+ * @param onNodeExecution 노드 실행 시작/종료 시 호출될 콜백 함수
+ */
+export const useNodeExecutionEvents = (onNodeExecution?: NodeExecutionEventHandler) => {
+  const nodes = useFlowStore(state => state.nodes);
+  const prevExecutingNodes = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    console.log('🔍 useNodeExecutionEvents: Checking nodes:', nodes.length);
+    console.log('🔍 All nodes data:', nodes.map(n => ({ id: n.id, isExecuting: n.data?.isExecuting })));
+    
+    const currentExecutingNodes = new Set<string>();
+    
+    // 현재 실행 중인 노드들 찾기
+    nodes.forEach(node => {
+      console.log(`🔍 Node ${node.id}: isExecuting = ${node.data?.isExecuting}`);
+      if (node.data?.isExecuting) {
+        console.log(`🔍 Found executing node: ${node.id}`);
+        currentExecutingNodes.add(node.id);
+      }
+    });
+
+    console.log('🔍 Current executing nodes:', Array.from(currentExecutingNodes));
+    console.log('🔍 Previous executing nodes:', Array.from(prevExecutingNodes.current));
+
+    // 이전 상태와 비교하여 이벤트 감지
+    const previousSet = prevExecutingNodes.current;
+    
+    // 새로 시작된 노드들
+    currentExecutingNodes.forEach(nodeId => {
+      if (!previousSet.has(nodeId)) {
+        console.log(`🎬 노드 실행 시작: ${nodeId}`);
+        onNodeExecution?.(nodeId, 'start');
+      }
+    });
+
+    // 종료된 노드들
+    previousSet.forEach(nodeId => {
+      if (!currentExecutingNodes.has(nodeId)) {
+        console.log(`🏁 노드 실행 종료: ${nodeId}`);
+        onNodeExecution?.(nodeId, 'end');
+      }
+    });
+
+    // 현재 상태를 이전 상태로 업데이트
+    prevExecutingNodes.current = new Set(currentExecutingNodes);
+  }, [nodes, onNodeExecution]);
+
+  // 현재 실행 중인 노드들 반환
+  const executingNodes = nodes
+    .filter(node => node.data?.isExecuting)
+    .map(node => ({
+      id: node.id,
+      type: node.type,
+      label: node.data?.label || 'Unnamed Node'
+    }));
+
+  return {
+    executingNodes,
+    isAnyNodeExecuting: executingNodes.length > 0
+  };
+};
+
+/**
+ * 특정 노드의 실행 상태만 감지하는 훅
+ * @param nodeId 감지할 노드 ID
+ * @param onExecutionChange 실행 상태 변경 시 호출될 콜백
+ */
+export const useNodeExecutionStatus = (
+  nodeId: string, 
+  onExecutionChange?: (isExecuting: boolean, nodeId: string) => void
+) => {
+  const node = useFlowStore(state => state.nodes.find(n => n.id === nodeId));
+  const prevExecuting = useRef<boolean>(false);
+
+  const isExecuting = node?.data?.isExecuting || false;
+
+  useEffect(() => {
+    if (prevExecuting.current !== isExecuting) {
+      console.log(`📊 노드 ${nodeId} 실행 상태 변경: ${prevExecuting.current} → ${isExecuting}`);
+      onExecutionChange?.(isExecuting, nodeId);
+      prevExecuting.current = isExecuting;
+    }
+  }, [isExecuting, nodeId, onExecutionChange]);
+
+  return {
+    isExecuting,
+    node
+  };
+};


### PR DESCRIPTION
[노드별 성공시 토스트 및 표기]
<img width="524" height="194" alt="image" src="https://github.com/user-attachments/assets/2e9325d7-3ad7-48e9-ae2a-a9befb25e9dd" />

[노드별 실패시 토스트 및 표기 ]
<img width="883" height="300" alt="image" src="https://github.com/user-attachments/assets/bce4784f-f943-4c99-a6f5-510a16c17f0e" />

[전체실행 성공 토스트]
<img width="532" height="171" alt="image" src="https://github.com/user-attachments/assets/6d5738b1-95cf-4b5c-a8ed-c3472662e6fa" />

[전체실행 실패 토스트]
<img width="802" height="263" alt="image" src="https://github.com/user-attachments/assets/fb8da535-7b35-4b5a-82ef-391dc0582546" />

[Node 내 Input Data error 발생시 표기 변경]
이전에는 오류가나도 초록색으로 성공처럼 보임
<img width="1166" height="569" alt="image" src="https://github.com/user-attachments/assets/b5ad1c1c-07f8-4b53-a63d-b7842b1cc67e" />


Releated to: #165 