### PR TITLE
205_Prompt_노드_Settings_설정_화면에_안내_문구_제거

### DIFF
--- a/ui/src/components/nodes/PromptSettings.tsx
+++ b/ui/src/components/nodes/PromptSettings.tsx
@@ -63,14 +63,6 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
 
   return (
     <div className="space-y-4 p-4">
-      <div>
-        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-          Prompt Settings
-        </h3>
-        <p className="text-xs text-gray-500 dark:text-gray-400">
-          Configure your prompt node settings here.
-        </p>
-      </div>
 
       <div>
         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">


### PR DESCRIPTION
<img width="377" height="478" alt="image" src="https://github.com/user-attachments/assets/06ecd06e-5fb3-4761-a64b-86076bbeac26" />

제거완료

Releated to : #205 