### PR TITLE
202 노드 이름 변경 시, 키보드가 한글일 경우 영어로 변경하여 입력되도록 개선

### DIFF
--- a/ui/src/components/NodeInspector.tsx
+++ b/ui/src/components/NodeInspector.tsx
@@ -302,6 +302,7 @@ const NodeInspector: React.FC<NodeInspectorProps> = ({ nodeId, selectedEdge, onC
     }
   };
 
+  
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = e.target.value;
     setNodeDescription(value);

--- a/ui/src/components/nodes/CustomNode.tsx
+++ b/ui/src/components/nodes/CustomNode.tsx
@@ -27,6 +27,7 @@ export const CustomNode = memo(({ data, isConnectable, id, type }: NodeProps) =>
   const [isRightHandleHovered, setIsRightHandleHovered] = useState(false);
   // 툴팁 표시 상태
   const [showTooltip, setShowTooltip] = useState(false);
+  
 
   // ToolsMemoryNode이고 다른 노드가 포커스되었을 때 selectedGroupId 초기화
   React.useEffect(() => {


### PR DESCRIPTION
<img width="197" height="113" alt="image" src="https://github.com/user-attachments/assets/9415c3ea-1a69-448a-b093-3c5b536b627c" />

1. 한글 입력시 에러 나오게 수정함 
- 영어를 자동으로 입력하게 할 경우, 일본어 중국어 아랍어 등 다양한 언어를 영어로 자동 변환하는데한계가 있었음 
- 입력은 허용하지만, 경고창을 나오게 수정하고 이전 이름으로 롤백 시킴

2. 백스페이스 delete 키 사용 가능



