### PR TITLE
274 사용자노드 생성시 예외 적용

### DIFF
--- a/ui/src/components/workspace/NodeDetail.tsx
+++ b/ui/src/components/workspace/NodeDetail.tsx
@@ -296,13 +296,24 @@ const NodeDetail: React.FC<NodeDetailProps> = ({ nodeId, onBack }) => {
 
   // Parameters가 변경될 때 함수 파라미터를 자동으로 업데이트하는 함수
   const updateFunctionParameters = (newParameters: Parameter[]) => {
+    // 파라미터 이름과 타입 힌트를 포함하여 생성
+    const createParamString = (param: Parameter): string => {
+      const paramName = param.funcArgs && param.funcArgs.trim() ? param.funcArgs.trim() : param.name.trim();
+      const paramType = param.type && param.type !== 'any' ? param.type : '';
+      
+      if (paramType) {
+        return `${paramName}: ${paramType}`;
+      }
+      return paramName;
+    };
+    
     const requiredParams = newParameters
       .filter(param => param.required && param.name.trim())
-      .map(param => param.funcArgs && param.funcArgs.trim() ? param.funcArgs.trim() : param.name.trim());
+      .map(param => createParamString(param));
     
     const optionalParams = newParameters
       .filter(param => !param.required && param.name.trim())
-      .map(param => param.funcArgs && param.funcArgs.trim() ? param.funcArgs.trim() : param.name.trim());
+      .map(param => createParamString(param));
     
     // 모든 파라미터를 required 먼저, 그 다음 optional 순으로 정렬
     const allParams = [...requiredParams, ...optionalParams];


### PR DESCRIPTION
## 변경의 이유 ( Motivation )
- 사용자 노드를 수정하는 경우, 사용자의 실수가 발생할 수 있는 영역이 존재해 에러와 버그를 만들어 낼 수 있어 예외처리가 필요함

## 변경의 종류 ( Type of Change )
- [ ] 문서 작성 ( Writing or updating documentation )
- [X] 버그 수정 ( Bug fix )
- [ ] 새 기능 ( New feature )
- [ ] 기능 변경 ( Modification of the existing feature )
- [ ] 리팩터링 ( Refactoring )
- [ ] 브레이킹 체인지 ( Breaking change )

## 변경 내용 ( Change List )
| 기능 | 생성 | 수정 | 필요성 | 이유 |
|------|------|------|--------|------|
| 파라미터 동기화 | ✅ | ✅ | 필요 | 코드-설정 일치성 유지 |
| 경고 시스템 | ✅ | ✅ | 필요 | 사용자 실수 방지 |
| 중복 검사 | ✅ | ✅ | 필요 | 노드 이름 변경 시 중복 방지 |
| 코드 검증 | ✅ | ✅ | 필요 | 코드 유효성 및 일치성 검증 |


## 관련 이슈 ( Related issue )
- Closes: #274 

## 기대 효과 ( Intended Effects )
- 사용자의 실수가 줄어들어 휴먼에러 최소화 

## 코드 품질 ( Code Quality )
- [X] 변경 사항을 자체적으로 리뷰했다.  
  I have performed a self-review of my own code
- [X] 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [X] 코드의 이해를 돕기 위해 적절한 곳에 주석을 작성했다.  
  I have commented my code, particularly in hard-to-understand parts
- [X] 코드를 검증하기 위한 단위 테스트를 추가했다.  
  I have added unit tests in order to verify the changes
- [X] 커밋은 이해하기 쉬운 순서와 적절한 크기로 분리했다.  
  I split up into logical, small, tactical commits

## 테스트 과정 ( How has this benn tested ? )
<img width="986" height="1308" alt="image" src="https://github.com/user-attachments/assets/71e19bc3-e7d9-42e7-9302-49e7c926b194" />

1. 사용자 노드를 들어간다
2. 사용자 노드를 수정한다. 
3. Parametes와 python code를 다르게 작성해본다. ( 경고 ) 
4. Basic Information와 python code를 다르게 작성해본다. ( 경고 ) 
5. 기존에 있던 이름으로 node name를 수정해본다. ( 저장 거부 ) 

## 리뷰어 체크리스트 ( Checklist for reviewers )
- [ ] 이 PR 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [ ] 변경 사항이 코딩 스타일 가이드를 준수하고 있다.  
  This PR follows the style guidelines
- [ ] [OWASP Top 10](https://owasp.org/www-project-top-ten/)을 고려해 보안 사항을 리뷰했다.  
  I have reviewed this PR against [OWASP Top 10](https://owasp.org/www-project-top-ten/)
- [ ] 전체 단위 테스트를 성공적으로 실행했다.  
  I have confirmed that all unit tests are passed
