### PR TITLE
282 End 노드 위치 변경 우측 기준으로 변경

### DIFF
--- a/ui/src/components/execution/ExecutionDetail.tsx
+++ b/ui/src/components/execution/ExecutionDetail.tsx
@@ -224,7 +224,7 @@ const ExecutionDetail: React.FC<ExecutionDetailProps> = ({ execution, onBack }) 
         {
           id: 'start',
           type: 'executionNode',
-          position: { x: (containerWidth - nodeWidth) / 2, y: startY },
+          position: { x: (containerWidth - 2 * nodeWidth - fixedSpacing) / 2, y: startY },
           data: {
             label: 'Start',
             description: 'Starting point of the workflow',
@@ -240,7 +240,7 @@ const ExecutionDetail: React.FC<ExecutionDetailProps> = ({ execution, onBack }) 
         {
           id: 'end',
           type: 'executionNode',
-          position: { x: (containerWidth - nodeWidth) / 2, y: startY + fixedSpacing },
+          position: { x: (containerWidth - 2 * nodeWidth - fixedSpacing) / 2 + nodeWidth + fixedSpacing, y: startY },
           data: {
             label: 'End',
             description: 'End point of the workflow',

--- a/ui/src/store/flowStore.ts
+++ b/ui/src/store/flowStore.ts
@@ -245,7 +245,7 @@ export const initialNodes: Node<NodeData>[] = [
   {
     id: 'end',
     type: 'endNode',
-    position: { x: 100, y: 300 },
+    position: { x: 400, y: 100 },
     data: {
       label: 'End',
       description: 'End point of the workflow',
@@ -279,7 +279,7 @@ export const emptyInitialNodes: Node<NodeData>[] = [
   {
     id: 'end',
     type: 'endNode',
-    position: { x: 100, y: 300 },
+    position: { x: 400, y: 100 },
     data: {
       label: 'End',
       description: 'End point of the workflow',


### PR DESCRIPTION
## 변경의 이유 ( Motivation )
- 기본적으로 Workflow 생성이 위아래가 아닌 옆으로 설계하는 방식이여서 기존 End 노드의 위치를 오른쪽 기준으로 설정되게 수정

## 변경의 종류 ( Type of Change )
- [ ] 문서 작성 ( Writing or updating documentation )
- [ ] 버그 수정 ( Bug fix )
- [ ] 새 기능 ( New feature )
- [X] 기능 변경 ( Modification of the existing feature )
- [ ] 리팩터링 ( Refactoring )
- [ ] 브레이킹 체인지 ( Breaking change )

## 변경 내용 ( Change List )
- End 노드의 위치를 Start 노드 오른쪽으로 변경

## 관련 이슈 ( Related issue )
- Closes: #282 

## 기대 효과 ( Intended Effects )
- End 노드의 위치 변경으로 가시성 확보

## 코드 품질 ( Code Quality )
- [X] 변경 사항을 자체적으로 리뷰했다.  
  I have performed a self-review of my own code
- [X] 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [X] 코드의 이해를 돕기 위해 적절한 곳에 주석을 작성했다.  
  I have commented my code, particularly in hard-to-understand parts
- [X] 코드를 검증하기 위한 단위 테스트를 추가했다.  
  I have added unit tests in order to verify the changes
- [X] 커밋은 이해하기 쉬운 순서와 적절한 크기로 분리했다.  
  I split up into logical, small, tactical commits

## 테스트 과정 ( How has this benn tested ? )
- 워크프로우 신규 생성시 End 노드의 위치가 Start 노드 오른쪽으로 생성되는지 확인
<img width="2558" height="1352" alt="image" src="https://github.com/user-attachments/assets/57a660b7-527d-48d4-bc50-5f8295392213" />


## 리뷰어 체크리스트 ( Checklist for reviewers )
- [x] 이 PR 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [x] 변경 사항이 코딩 스타일 가이드를 준수하고 있다.  
  This PR follows the style guidelines
- [x] [OWASP Top 10](https://owasp.org/www-project-top-ten/)을 고려해 보안 사항을 리뷰했다.  
  I have reviewed this PR against [OWASP Top 10](https://owasp.org/www-project-top-ten/)
- [x] 전체 단위 테스트를 성공적으로 실행했다.  
  I have confirmed that all unit tests are passed
