### PR TITLE
292 tool&memory 노드 이름 수정 및 Agent 노드 연결 시 에러 수정

### DIFF
--- a/ui/src/components/Common/MultiSelect.tsx
+++ b/ui/src/components/Common/MultiSelect.tsx
@@ -5,6 +5,8 @@ interface MultiSelectOption {
   value: string;
   label: string;
   description?: string;
+  nodeName?: string;
+  nodeId?: string;
 }
 
 interface MultiSelectProps {
@@ -14,6 +16,7 @@ interface MultiSelectProps {
   placeholder?: string;
   disabled?: boolean;
   maxHeight?: string;
+  singleSelection?: boolean; // 단일 선택 모드
 }
 
 const MultiSelect: React.FC<MultiSelectProps> = ({
@@ -22,7 +25,8 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
   options,
   placeholder = 'Select options...',
   disabled = false,
-  maxHeight = 'max-h-48'
+  maxHeight = 'max-h-48',
+  singleSelection = false
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -81,19 +85,47 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
   }, [isOpen, highlightedIndex, options]);
 
   const toggleOption = (optionValue: string) => {
-    const newValue = value.includes(optionValue)
-      ? value.filter(v => v !== optionValue)
-      : [...value, optionValue];
-    onChange(newValue);
+    if (singleSelection) {
+      // 단일 선택 모드: 다른 값 선택 시 기존 선택 해제
+      if (value.includes(optionValue)) {
+        // 이미 선택된 값을 다시 클릭하면 해제
+        onChange([]);
+      } else {
+        // 새로운 값 선택 (기존 선택 자동 해제)
+        onChange([optionValue]);
+      }
+    } else {
+      // 다중 선택 모드: 기존 로직 유지
+      const newValue = value.includes(optionValue)
+        ? value.filter(v => v !== optionValue)
+        : [...value, optionValue];
+      onChange(newValue);
+    }
   };
 
   const removeOption = (optionValue: string, event: React.MouseEvent) => {
     event.stopPropagation();
-    const newValue = value.filter(v => v !== optionValue);
-    onChange(newValue);
+    if (singleSelection) {
+      // 단일 선택 모드에서는 선택 해제
+      onChange([]);
+    } else {
+      // 다중 선택 모드에서는 해당 항목만 제거
+      const newValue = value.filter(v => v !== optionValue);
+      onChange(newValue);
+    }
   };
 
   const selectedOptions = options.filter(option => value.includes(option.value));
+
+  // 노드별로 그룹핑
+  const groupedOptions = options.reduce((acc, option) => {
+    const nodeName = option.nodeName || 'Unknown Node';
+    if (!acc[nodeName]) {
+      acc[nodeName] = [];
+    }
+    acc[nodeName].push(option);
+    return acc;
+  }, {} as Record<string, MultiSelectOption[]>);
 
   return (
     <div className="relative" ref={containerRef}>
@@ -116,6 +148,11 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
               className="bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-300 px-2 py-1 rounded-md text-sm flex items-center gap-1"
             >
               <span className="truncate max-w-[120px]">{option.label}</span>
+              {option.nodeName && (
+                <span className="text-xs text-blue-600 dark:text-blue-400 bg-blue-200 dark:bg-blue-800 px-1 rounded">
+                  {option.nodeName}
+                </span>
+              )}
               <button
                 type="button"
                 onClick={(e) => removeOption(option.value, e)}
@@ -154,41 +191,60 @@ const MultiSelect: React.FC<MultiSelectProps> = ({
               No options available
             </div>
           ) : (
-            options.map((option, index) => {
-              const isSelected = value.includes(option.value);
-              const isHighlighted = index === highlightedIndex;
-              
-              return (
-                <div
-                  key={option.value}
-                  className={`px-4 py-2 cursor-pointer text-sm flex items-center gap-2 transition-colors ${
-                    isSelected 
-                      ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300' 
-                      : isHighlighted
-                      ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
-                      : 'text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700'
-                  }`}
-                  onClick={() => toggleOption(option.value)}
-                  onMouseEnter={() => setHighlightedIndex(index)}
-                  role="option"
-                  aria-selected={isSelected}
-                >
-                  <div className="flex items-center justify-center w-4 h-4">
-                    {isSelected && (
-                      <Check size={14} className="text-blue-600 dark:text-blue-400" />
-                    )}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium truncate">{option.label}</div>
-                    {option.description && (
-                      <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                        {option.description}
-                      </div>
-                    )}
+            Object.entries(groupedOptions).map(([nodeName, nodeOptions]) => (
+              <div key={nodeName} className="border-b border-gray-200 dark:border-gray-700 last:border-b-0">
+                {/* 노드 헤더 */}
+                <div className="px-4 py-2 bg-gray-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
+                  <div className="flex items-center gap-2">
+                    <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
+                    <span className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+                      {nodeName}
+                    </span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      ({nodeOptions.length} items)
+                    </span>
                   </div>
                 </div>
-              );
-            })
+                
+                {/* 노드의 옵션들 */}
+                {nodeOptions.map((option) => {
+                  const globalIndex = options.findIndex(opt => opt.value === option.value);
+                  const isSelected = value.includes(option.value);
+                  const isHighlighted = globalIndex === highlightedIndex;
+                  
+                  return (
+                    <div
+                      key={option.value}
+                      className={`px-6 py-2 cursor-pointer text-sm flex items-center gap-2 transition-colors ${
+                        isSelected 
+                          ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300' 
+                          : isHighlighted
+                          ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+                          : 'text-gray-900 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700'
+                      }`}
+                      onClick={() => toggleOption(option.value)}
+                      onMouseEnter={() => setHighlightedIndex(globalIndex)}
+                      role="option"
+                      aria-selected={isSelected}
+                    >
+                      <div className="flex items-center justify-center w-4 h-4">
+                        {isSelected && (
+                          <Check size={14} className="text-blue-600 dark:text-blue-400" />
+                        )}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium truncate">{option.label}</div>
+                        {option.description && (
+                          <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                            {option.description}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))
           )}
         </div>
       )}

--- a/ui/src/components/nodes/CustomNode.tsx
+++ b/ui/src/components/nodes/CustomNode.tsx
@@ -701,7 +701,7 @@ export const CustomNode = memo(({ data, isConnectable, id, type }: NodeProps) =>
                   className="text-xs"
                   style={{ color: nodeStyle.textColor }}
                 >
-                  Tools & Memory Configuration
+                  Tools and Memory Configuration
                 </p>
               </div>
             </div>

--- a/ui/src/data/nodeCategories.tsx
+++ b/ui/src/data/nodeCategories.tsx
@@ -78,7 +78,7 @@ export const nodeCategories: NodeCategory[] = [
       },
       {
         type: 'toolsMemoryNode',
-        label: 'Tools&Memory',
+        label: 'Tools and Memory',
         description: getNodeCategoryDescription('toolsMemoryNode'),
         icon: (className = '', isDarkMode = false) => (
           <Group size={20} className={className} style={{ color: getIconColor('toolsMemoryNode', isDarkMode) }} />


### PR DESCRIPTION
## 변경의 이유 ( Motivation )
- 필요 없는 경고 제거
- tool_and_memory 최초 한개만 적용되어 불편함 

## 변경의 종류 ( Type of Change )
- [ ] 문서 작성 ( Writing or updating documentation )
- [X] 버그 수정 ( Bug fix )
- [ ] 새 기능 ( New feature )
- [ ] 기능 변경 ( Modification of the existing feature )
- [ ] 리팩터링 ( Refactoring )
- [ ] 브레이킹 체인지 ( Breaking change )

## 변경 내용 ( Change List )
MultiSelect에 단일 선택 모드 추가:
- singleSelection prop을 추가하여 단일 선택 모드를 지원
- 단일 선택 모드에서는 다른 값을 선택하면 기존 선택이 자동으로 해제됨
이미 선택된 값을 다시 클릭하면 선택 해제됨
- Memory Group에 단일 선택 적용:
- singleSelection={true} prop을 추가하여 Memory Group이 단일 선택으로 동작하도록 설정
동작 방식:
- 다중 선택 모드 (Tools): 여러 개 선택 가능, 각각 토글 가능
- 단일 선택 모드 (Memory Group): 하나만 선택 가능, 다른 값 선택 시 기존 선택 자동 해제

## 관련 이슈 ( Related issue )
- Closes: #292 

## 기대 효과 ( Intended Effects )
- 사용 편의성 증가

## 코드 품질 ( Code Quality )
- [X] 변경 사항을 자체적으로 리뷰했다.  
  I have performed a self-review of my own code
- [X] 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [X] 코드의 이해를 돕기 위해 적절한 곳에 주석을 작성했다.  
  I have commented my code, particularly in hard-to-understand parts
- [X] 코드를 검증하기 위한 단위 테스트를 추가했다.  
  I have added unit tests in order to verify the changes
- [X] 커밋은 이해하기 쉬운 순서와 적절한 크기로 분리했다.  
  I split up into logical, small, tactical commits

## 테스트 과정 ( How has this benn tested ? )
<img width="418" height="299" alt="image" src="https://github.com/user-attachments/assets/e2f143f6-6c77-4e9f-bbb4-b3934384d91a" />

1. TOOL AND MEMORY 노드 2개 생성
2. AGENT 노드에 MEMORY와 TOOL를 각각의 노드에서 찾아서 설정

## 리뷰어 체크리스트 ( Checklist for reviewers )
- [ ] 이 PR 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [ ] 변경 사항이 코딩 스타일 가이드를 준수하고 있다.  
  This PR follows the style guidelines
- [ ] [OWASP Top 10](https://owasp.org/www-project-top-ten/)을 고려해 보안 사항을 리뷰했다.  
  I have reviewed this PR against [OWASP Top 10](https://owasp.org/www-project-top-ten/)
- [ ] 전체 단위 테스트를 성공적으로 실행했다.  
  I have confirmed that all unit tests are passed
