### PR TITLE
294 노드이름과 return 값 동일하게 변경

### DIFF
--- a/ui/src/store/flowStore.ts
+++ b/ui/src/store/flowStore.ts
@@ -920,27 +920,27 @@ export const useFlowStore = create<FlowState>((set, get) => ({
       classType: 'TypedDict' as const,
       variables: []
     } : type === 'functionNode' ? { // functionNode (Custom Python Function) 기본 설정
-      outputVariable: 'python_function_output',
+      outputVariable: uniqueLabel,
       // code는 newNode 생성 시 data에 직접 설정합니다.
     } : type === 'loopNode' ? {
       repetitions: 1
     } : type === 'promptNode' ? { // promptNode에 outputVariable 기본값 추가
       template: 'User: {{user_input}}\n\nAssistant:',
-      outputVariable: 'user_input'
+      outputVariable: uniqueLabel
     } : type === 'agentNode' ? {
       model: '',
       userPromptInputKey: '',
       systemPromptInputKey: '',
       memoryGroup: '',
       tools: [],
-      agentOutputVariable: 'agent_response'
+      agentOutputVariable: uniqueLabel
     } : type === 'mergeNode' ? {
       mergeMappings: []
     } : type === 'endNode' ? {
       receiveKey: ''
     } : type === 'userNode' ? {
       // UserNode의 경우 data.config에서 가져온 설정을 사용하되, 기본값도 제공
-      outputVariable: 'result',
+      outputVariable: uniqueLabel,
       ...data.config
     } : {};
 


### PR DESCRIPTION
## 변경의 이유 ( Motivation )
- 전에는 각 노드 타입별로 고정된 기본값(user_input, agent_response, python_function_output, result)을 사용했지만 값을 유지하고 싶은 경우, 수정을 해야 해서 불편함

## 변경의 종류 ( Type of Change )
- [ ] 문서 작성 ( Writing or updating documentation )
- [ ] 버그 수정 ( Bug fix )
- [ ] 새 기능 ( New feature )
- [X] 기능 변경 ( Modification of the existing feature )
- [ ] 리팩터링 ( Refactoring )
- [ ] 브레이킹 체인지 ( Breaking change )

## 변경 내용 ( Change List )
| 노드 타입 | Output Variable 이름 | 이전 기본값 | 변경 후 기본값 |
|------------|----------------------|--------------|----------------|
| Prompt Node | outputVariable | 'user_input' | 노드 이름 |
| Agent Node | agentOutputVariable | 'agent_response' | 노드 이름 |
| User Node | outputVariable | 'result' | 노드 이름 |


## 관련 이슈 ( Related issue )
- Closes: #294 

## 기대 효과 ( Intended Effects )
- 사용자의 불편함 해소, 개발 속도 향상

## 코드 품질 ( Code Quality )
- [X] 변경 사항을 자체적으로 리뷰했다.  
  I have performed a self-review of my own code
- [X] 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [X] 코드의 이해를 돕기 위해 적절한 곳에 주석을 작성했다.  
  I have commented my code, particularly in hard-to-understand parts
- [X] 코드를 검증하기 위한 단위 테스트를 추가했다.  
  I have added unit tests in order to verify the changes
- [X] 커밋은 이해하기 쉬운 순서와 적절한 크기로 분리했다.  
  I split up into logical, small, tactical commits

## 테스트 과정 ( How has this benn tested ? )
<img width="648" height="372" alt="image" src="https://github.com/user-attachments/assets/4b7de1c6-65e8-401f-b60c-d26b154581c5" />

노드를 생성해 보고 outputVariable 값이 노드 이름과 동일한지 체크한다.

## 리뷰어 체크리스트 ( Checklist for reviewers )
- [ ] 이 PR 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [ ] 변경 사항이 코딩 스타일 가이드를 준수하고 있다.  
  This PR follows the style guidelines
- [ ] [OWASP Top 10](https://owasp.org/www-project-top-ten/)을 고려해 보안 사항을 리뷰했다.  
  I have reviewed this PR against [OWASP Top 10](https://owasp.org/www-project-top-ten/)
- [ ] 전체 단위 테스트를 성공적으로 실행했다.  
  I have confirmed that all unit tests are passed
