### PR TITLE
296 Prompt 다중설정

### DIFF
--- a/ui/src/components/nodes/PromptSettings.tsx
+++ b/ui/src/components/nodes/PromptSettings.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import CodeEditor from '../CodeEditor';
 import { useFlowStore } from '../../store/flowStore';
-import { AlertCircle, Pencil, Check, Maximize2, FileText } from 'lucide-react';
+import { AlertCircle, Pencil, Check, Maximize2, FileText, Plus, Trash2 } from 'lucide-react';
 import CustomSelect from '../Common/CustomSelect';
 import PromptTemplatePopup from './PromptTemplatePopup';
 
@@ -9,12 +9,24 @@ interface PromptSettingsProps {
   nodeId: string;
 }
 
+interface PromptConfig {
+  template: string;
+}
+
+interface PromptsData {
+  [key: string]: PromptConfig;
+}
+
 const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
   const { nodes, edges, updateNodeData } = useFlowStore();
   const node = nodes.find(n => n.id === nodeId);
   const [isEditingOutputVariable, setIsEditingOutputVariable] = useState(false);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [activePromptKey, setActivePromptKey] = useState<string | null>(null);
+  const [isEditingKey, setIsEditingKey] = useState(false);
+  const [editingKeyValue, setEditingKeyValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  const keyInputRef = useRef<HTMLInputElement>(null);
   const incomingEdge = edges.find(edge => edge.target === nodeId);
 
   const sourceOutput = incomingEdge?.data?.output || null;
@@ -26,6 +38,35 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
   // Get source node info
   const sourceNode = nodes.find(n => n.id === incomingEdge?.source);
 
+  // Get prompts data from node config
+  const prompts: PromptsData = node?.data?.config?.prompts || {};
+  const promptKeys = Object.keys(prompts);
+
+  // Initialize active prompt key
+  useEffect(() => {
+    if (promptKeys.length > 0 && !activePromptKey) {
+      setActivePromptKey(promptKeys[0]);
+    } else if (promptKeys.length === 0) {
+      // Initialize with default prompt
+      const defaultKey = 'prompt_1';
+      updateNodeData(nodeId, {
+        ...node?.data,
+        config: {
+          ...(node?.data?.config || {}),
+          prompts: {
+            [defaultKey]: {
+              template: node?.data?.config?.template || ''
+            }
+          },
+          outputVariable: node?.data?.config?.outputVariable || ''
+        }
+      });
+      setActivePromptKey(defaultKey);
+    }
+  }, []);
+
+  const activePrompt = activePromptKey ? prompts[activePromptKey] : null;
+
   // Auto focus and position cursor at the end when editing starts
   useEffect(() => {
     if (isEditingOutputVariable && inputRef.current) {
@@ -36,40 +77,192 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
     }
   }, [isEditingOutputVariable]);
 
+  // Auto focus for key editing
+  useEffect(() => {
+    if (isEditingKey && keyInputRef.current) {
+      keyInputRef.current.focus();
+      const value = keyInputRef.current.value;
+      keyInputRef.current.setSelectionRange(value.length, value.length);
+    }
+  }, [isEditingKey]);
+
+  const handleAddPrompt = () => {
+    const newKey = `prompt_${promptKeys.length + 1}`;
+    const newPrompts = {
+      ...prompts,
+      [newKey]: {
+        template: ''
+      }
+    };
+    updateNodeData(nodeId, {
+      ...node?.data,
+      config: {
+        ...(node?.data?.config || {}),
+        prompts: newPrompts
+      }
+    });
+    setActivePromptKey(newKey);
+  };
+
+  const handleDeletePrompt = (key: string) => {
+    if (promptKeys.length <= 1) {
+      alert('최소 1개의 프롬프트가 필요합니다.');
+      return;
+    }
+    
+    const newPrompts = { ...prompts };
+    delete newPrompts[key];
+    
+    updateNodeData(nodeId, {
+      ...node?.data,
+      config: {
+        ...(node?.data?.config || {}),
+        prompts: newPrompts
+      }
+    });
+    
+    // Set active key to first remaining prompt
+    const remainingKeys = Object.keys(newPrompts);
+    if (remainingKeys.length > 0) {
+      setActivePromptKey(remainingKeys[0]);
+    }
+  };
+
+  const handleRenamePromptKey = (oldKey: string, newKey: string) => {
+    // 먼저 편집 모드를 종료하여 onBlur 이벤트 반복 방지
+    setIsEditingKey(false);
+    
+    if (oldKey === newKey) {
+      return;
+    }
+    
+    if (prompts[newKey]) {
+      // 에러 발생 시 원래 값으로 복원
+      setEditingKeyValue(oldKey);
+      alert('이미 존재하는 key입니다.');
+      return;
+    }
+    
+    if (!newKey.trim()) {
+      // 에러 발생 시 원래 값으로 복원
+      setEditingKeyValue(oldKey);
+      alert('key는 비어있을 수 없습니다.');
+      return;
+    }
+    
+    const newPrompts: PromptsData = {};
+    Object.keys(prompts).forEach(k => {
+      if (k === oldKey) {
+        newPrompts[newKey] = prompts[k];
+      } else {
+        newPrompts[k] = prompts[k];
+      }
+    });
+    
+    updateNodeData(nodeId, {
+      ...node?.data,
+      config: {
+        ...(node?.data?.config || {}),
+        prompts: newPrompts
+      }
+    });
+    
+    setActivePromptKey(newKey);
+  };
+
   const handleOutputVariableChange = (value: string) => {
     if (!node || !node.data) {
       console.warn(`[PromptSettings] Node data for node ID ${nodeId} is not available. Cannot update outputVariable.`);
       return;
     }
+    
     updateNodeData(nodeId, {
-      // node.data is now guaranteed to be defined here
       ...node.data,
       config: {
-        // node.data.config might still be undefined, so handle it
         ...(node.data.config || {}),
         outputVariable: value
       }
     });
   };
 
-  const handleTemplateChange = (value: string) => {
+  // 단일 프롬프트 템플릿 변경 (메인 화면 CodeEditor용)
+  const handleTemplateChange = (promptKey: string, value: string) => {
     if (!node || !node.data) {
       console.warn(`[PromptSettings] Node data for node ID ${nodeId} is not available. Cannot update template.`);
       return;
     }
+    
+    const newPrompts = {
+      ...prompts,
+      [promptKey]: {
+        ...prompts[promptKey],
+        template: value
+      }
+    };
+    
     updateNodeData(nodeId, {
-      // node.data is now guaranteed to be defined here
       ...node.data,
       config: {
-        // node.data.config might still be undefined, so handle it
         ...(node.data.config || {}),
-        template: value
+        prompts: newPrompts
       }
     });
   };
 
+  // 여러 프롬프트 템플릿 일괄 변경 (Popup Save용 - 템플릿만)
+  const handleBulkTemplateChange = (updates: Record<string, string>) => {
+    if (!node || !node.data) {
+      console.warn(`[PromptSettings] Node data for node ID ${nodeId} is not available. Cannot update templates.`);
+      return;
+    }
+    
+    const newPrompts = { ...prompts };
+    Object.entries(updates).forEach(([key, template]) => {
+      newPrompts[key] = {
+        ...newPrompts[key],
+        template
+      };
+    });
+    
+    console.log('[PromptSettings] Bulk updating prompts:', updates);
+    updateNodeData(nodeId, {
+      ...node.data,
+      config: {
+        ...(node.data.config || {}),
+        prompts: newPrompts
+      }
+    });
+  };
+
+  // 전체 프롬프트 구조 저장 (Popup Save용 - 추가/삭제/이름변경/내용변경 모두 포함)
+  const handleBulkSave = (newPrompts: PromptsData) => {
+    if (!node || !node.data) {
+      console.warn(`[PromptSettings] Node data for node ID ${nodeId} is not available. Cannot save prompts.`);
+      return;
+    }
+    
+    console.log('[PromptSettings] Saving entire prompts structure:', Object.keys(newPrompts));
+    updateNodeData(nodeId, {
+      ...node.data,
+      config: {
+        ...(node.data.config || {}),
+        prompts: newPrompts
+      }
+    });
+    
+    // activePromptKey가 삭제된 경우 첫 번째 키로 변경
+    const newKeys = Object.keys(newPrompts);
+    if (activePromptKey && !newPrompts[activePromptKey] && newKeys.length > 0) {
+      setActivePromptKey(newKeys[0]);
+    }
+  };
+
   if (!node) {
     return <div>Node not found</div>;
+  }
+
+  if (!activePromptKey) {
+    return <div>Loading...</div>;
   }
 
   return (
@@ -85,6 +278,7 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
         </div>
       </div>
 
+      {/* Output Variable Section */}
       <div>
         <label className={`block text-sm font-medium mb-1 ${
           !incomingEdge 
@@ -93,6 +287,16 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
         }`}>
           Output Variable
         </label>
+        <div className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+          결과 형식: {'{'}
+          {promptKeys.map((key, idx) => (
+            <span key={key}>
+              {key}: 'result'
+              {idx < promptKeys.length - 1 ? ', ' : ''}
+            </span>
+          ))}
+          {'}'}
+        </div>
         <div className="relative">
           <div className="flex items-center space-x-2">
             {isEditingOutputVariable ? (
@@ -101,7 +305,7 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
                   ref={inputRef}
                   type="text"
                   id="promptOutputVariableInput"
-                  value={node?.data.config?.outputVariable || ''}
+                  value={node?.data?.config?.outputVariable || ''}
                   onChange={(e) => handleOutputVariableChange(e.target.value)}
                   placeholder="Enter output variable name"
                   className={`flex-grow px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm ${
@@ -124,12 +328,12 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
               </>
             ) : (
               <>
-                <div className={!incomingEdge ? 'opacity-60' : ''}>
+                <div className={`flex-grow ${!incomingEdge ? 'opacity-60' : ''}`}>
                   <CustomSelect
-                    value={node?.data.config?.outputVariable || ''}
+                    value={node?.data?.config?.outputVariable || ''}
                     onChange={handleOutputVariableChange}
                     options={[
-                      ...(node?.data.config?.outputVariable && !availableVariables.includes(node.data.config.outputVariable)
+                      ...(node?.data?.config?.outputVariable && !availableVariables.includes(node.data.config.outputVariable)
                         ? [{ value: node.data.config.outputVariable, label: `${node.data.config.outputVariable} (Custom)` }]
                         : []),
                       ...availableVariables.map(variable => ({ value: variable, label: variable }))
@@ -167,6 +371,80 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
         </div>
       </div>
 
+      {/* Prompts Tabs Section */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+          Prompts
+        </label>
+        <div className="flex items-center space-x-2 overflow-x-auto pb-2">
+          {promptKeys.map((key) => (
+            <div
+              key={key}
+              className={`flex items-center space-x-2 px-3 py-2 rounded-md border cursor-pointer transition-colors ${
+                activePromptKey === key
+                  ? 'bg-purple-50 dark:bg-purple-900/30 border-purple-300 dark:border-purple-600'
+                  : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700'
+              }`}
+              onClick={() => setActivePromptKey(key)}
+            >
+              {isEditingKey && activePromptKey === key ? (
+                <input
+                  ref={keyInputRef}
+                  type="text"
+                  value={editingKeyValue}
+                  onChange={(e) => setEditingKeyValue(e.target.value)}
+                  onBlur={() => handleRenamePromptKey(key, editingKeyValue)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleRenamePromptKey(key, editingKeyValue);
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault();
+                      setIsEditingKey(false);
+                      setEditingKeyValue(key);
+                    }
+                  }}
+                  className="w-24 px-2 py-1 text-sm border border-purple-300 dark:border-purple-600 rounded bg-white dark:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                  onClick={(e) => e.stopPropagation()}
+                />
+              ) : (
+                <span
+                  className="text-sm font-medium"
+                  onDoubleClick={(e) => {
+                    e.stopPropagation();
+                    setIsEditingKey(true);
+                    setEditingKeyValue(key);
+                  }}
+                >
+                  {key}
+                </span>
+              )}
+              {activePromptKey === key && promptKeys.length > 1 && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDeletePrompt(key);
+                  }}
+                  className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                  title="Delete prompt"
+                >
+                  <Trash2 size={14} />
+                </button>
+              )}
+            </div>
+          ))}
+          <button
+            onClick={handleAddPrompt}
+            className="flex items-center space-x-1 px-3 py-2 rounded-md border border-dashed border-gray-400 dark:border-gray-500 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 hover:border-gray-500 dark:hover:border-gray-400 transition-colors"
+            title="Add new prompt"
+          >
+            <Plus size={16} />
+            <span className="text-sm">추가</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Prompt Template Section */}
       <div>
         <div className="flex items-center justify-between mb-1">
           <label className="flex items-center space-x-2 text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -184,8 +462,8 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
         </div>
         <div className="h-64 border border-gray-300 dark:border-gray-600 rounded-md">
           <CodeEditor
-            value={node?.data.config?.template || ''}
-            onChange={handleTemplateChange}
+            value={activePrompt?.template || ''}
+            onChange={(value) => handleTemplateChange(activePromptKey, value)}
             language="markdown"
           />
         </div>
@@ -195,8 +473,12 @@ const PromptSettings: React.FC<PromptSettingsProps> = ({ nodeId }) => {
       <PromptTemplatePopup
         isOpen={isPopupOpen}
         onClose={() => setIsPopupOpen(false)}
-        value={node?.data.config?.template || ''}
+        prompts={prompts}
+        activePromptKey={activePromptKey || ''}
         onChange={handleTemplateChange}
+        onBulkChange={handleBulkTemplateChange}
+        onBulkSave={handleBulkSave}
+        onChangeActivePrompt={setActivePromptKey}
         edgeData={sourceOutput}
         sourceNode={sourceNode}
         availableVariables={availableVariables}

--- a/ui/src/store/flowStore.ts
+++ b/ui/src/store/flowStore.ts
@@ -1419,31 +1419,84 @@ export const useFlowStore = create<FlowState>((set, get) => ({
 
       switch (node.type) {
         case 'promptNode': {
-          const template = node.data.config?.template || '';
+          const prompts = node.data.config?.prompts || {};
           const outputVariable = node.data.config?.outputVariable || '';
           
           if (!outputVariable) {
             output = { error: 'Output variable name is required' };
             break;
           }
-          // output = processPromptTemplate(template, input, outputVariable);
+          
+          const promptKeys = Object.keys(prompts);
+          if (promptKeys.length === 0) {
+            output = { error: 'No prompts configured' };
+            break;
+          }
+          
           try {
-            const payload = {
-              prompt: template,
-              param: input,
-              return_key: outputVariable,
-            };
-            const response = await fetch('http://localhost:8000/workflow/node/promptnode', {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify(payload),
-            });
-            if (!response.ok) {
-              throw new Error(`API request failed with status ${response.status}`);
+            // 각 프롬프트를 순차적으로 실행
+            const promptResults: Record<string, any> = {};
+            
+            for (const promptKey of promptKeys) {
+              const template = prompts[promptKey].template || '';
+              
+              const payload = {
+                prompt: template,
+                param: input,
+                return_key: promptKey,
+              };
+              
+              console.log(`[PromptNode] Executing prompt "${promptKey}" with template:`, template);
+              
+              const response = await fetch('http://localhost:8000/workflow/node/promptnode', {
+                method: 'POST',
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+              });
+              
+              if (!response.ok) {
+                throw new Error(`API request failed with status ${response.status} for prompt: ${promptKey}`);
+              }
+              
+              const apiResponse = await response.json();
+              console.log(`[PromptNode] API response for "${promptKey}":`, apiResponse);
+              
+              // API 응답에서 promptKey에 해당하는 값만 추출
+              // API는 { [return_key]: "처리된 결과" } 형태로 응답
+              if (apiResponse && typeof apiResponse === 'object' && promptKey in apiResponse) {
+                const result = apiResponse[promptKey];
+                // 결과가 문자열이면 그대로 사용, 아니면 전체 객체 사용
+                promptResults[promptKey] = typeof result === 'string' ? result : result;
+              } else {
+                // return_key로 응답하지 않은 경우, 전체 응답에서 문자열 찾기
+                console.warn(`[PromptNode] API response does not contain key "${promptKey}". Using fallback.`);
+                
+                // 응답이 단순 문자열인 경우
+                if (typeof apiResponse === 'string') {
+                  promptResults[promptKey] = apiResponse;
+                } 
+                // 응답 객체에서 첫 번째 문자열 값을 찾기
+                else if (typeof apiResponse === 'object') {
+                  const firstStringValue = Object.values(apiResponse).find(val => typeof val === 'string');
+                  promptResults[promptKey] = firstStringValue || JSON.stringify(apiResponse);
+                } 
+                else {
+                  promptResults[promptKey] = String(apiResponse);
+                }
+              }
+              
+              console.log(`[PromptNode] Stored result for "${promptKey}":`, promptResults[promptKey]);
             }
-            output = await response.json();
+            
+            // 입력 데이터에 outputVariable로 프롬프트 결과들을 추가
+            output = { 
+              ...input, 
+              [outputVariable]: promptResults 
+            };
+            
+            console.log(`[PromptNode] 실행 완료. 최종 output:`, output);
           } catch (apiError) {
             console.error('PromptNode API call failed:', apiError);
             output = { error: 'Failed to connect to prompt node API', details: (apiError as Error).message };


### PR DESCRIPTION
## 변경의 이유 ( Motivation )
- chat flow가 너무 길어지고, prompt 작성의 귀찮음이 존재함

## 변경의 종류 ( Type of Change )
- [ ] 문서 작성 ( Writing or updating documentation )
- [ ] 버그 수정 ( Bug fix )
- [ ] 새 기능 ( New feature )
- [X] 기능 변경 ( Modification of the existing feature )
- [ ] 리팩터링 ( Refactoring )
- [ ] 브레이킹 체인지 ( Breaking change )

## 변경 내용 ( Change List )
- PROMPT 노드에서 다중 PROMPT 관리가 가능하다. 

## 관련 이슈 ( Related issue )
- Closes: #296 

## 기대 효과 ( Intended Effects )
- CHAT FLOW 길이가 짧아지고 생산성이 올라간다.

## 코드 품질 ( Code Quality )
- [X] 변경 사항을 자체적으로 리뷰했다.  
  I have performed a self-review of my own code
- [X] 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [X] 코드의 이해를 돕기 위해 적절한 곳에 주석을 작성했다.  
  I have commented my code, particularly in hard-to-understand parts
- [X] 코드를 검증하기 위한 단위 테스트를 추가했다.  
  I have added unit tests in order to verify the changes
- [X] 커밋은 이해하기 쉬운 순서와 적절한 크기로 분리했다.  
  I split up into logical, small, tactical commits

## 테스트 과정 ( How has this benn tested ? )
<img width="712" height="469" alt="image" src="https://github.com/user-attachments/assets/dca126c2-9807-4a6e-a196-5397ea5349e6" />

PROMT를 다중으로 입력해서 전달해 본다.

## 리뷰어 체크리스트 ( Checklist for reviewers )
- [ ] 이 PR 변경 사항을 로컬에서 테스트했다.  
  I have tested on my local environment
- [ ] 변경 사항이 코딩 스타일 가이드를 준수하고 있다.  
  This PR follows the style guidelines
- [ ] [OWASP Top 10](https://owasp.org/www-project-top-ten/)을 고려해 보안 사항을 리뷰했다.  
  I have reviewed this PR against [OWASP Top 10](https://owasp.org/www-project-top-ten/)
- [ ] 전체 단위 테스트를 성공적으로 실행했다.  
  I have confirmed that all unit tests are passed
